### PR TITLE
chore: set app version to 1.0.0

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,12 +12,12 @@ from routers import auth, goals, transactions, recurring, debts, ai
 
 models.Base.metadata.create_all(bind=engine)
 
-app = FastAPI()
+app = FastAPI(title="BuFin API", version="1.0.0")
 
 # CORS Middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=["http://localhost:5173", "http://localhost:5174"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bufin",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- `package.json` version corrected from 0.0.0 to 1.0.0 to reflect the app's actual current version.
- Backend FastAPI app now reports `version="1.0.0"` (visible on `/docs`), and picks up the CORS `localhost:5174` addition that was sitting uncommitted locally.

Going forward, each phase's PR will include a version bump alongside the change.

## Test plan
- [ ] Confirm `/docs` on the backend shows version 1.0.0
- [ ] Confirm `npm run build` still succeeds