### PR TITLE
Phase 3: Budgets (budget-vs-actual)

### DIFF
--- a/backend/alembic/versions/3d52f3495e78_add_budgets_table.py
+++ b/backend/alembic/versions/3d52f3495e78_add_budgets_table.py
@@ -1,0 +1,43 @@
+"""add budgets table
+
+Revision ID: 3d52f3495e78
+Revises: 7cfbe9aa43f0
+Create Date: 2026-07-03 01:38:40.233556
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3d52f3495e78'
+down_revision: Union[str, Sequence[str], None] = '7cfbe9aa43f0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Autogenerate produced a no-op here because create_all() (which main.py runs on every
+    # app import) had already created this table as a side effect of local testing. Written
+    # out explicitly so this migration is meaningful for a fresh/pre-existing database too.
+    op.create_table(
+        'budgets',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('user_id', sa.String(), nullable=True),
+        sa.Column('category', sa.String(), nullable=True),
+        sa.Column('monthlyLimit', sa.Float(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    with op.batch_alter_table('budgets') as batch_op:
+        batch_op.create_index(batch_op.f('ix_budgets_id'), ['id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('budgets') as batch_op:
+        batch_op.drop_index(batch_op.f('ix_budgets_id'))
+    op.drop_table('budgets')

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ from routers import auth, goals, transactions, recurring, debts, ai, budgets
 
 models.Base.metadata.create_all(bind=engine)
 
-app = FastAPI(title="BuFin API", version="1.1.0")
+app = FastAPI(title="BuFin API", version="1.2.0")
 
 # CORS Middleware
 app.add_middleware(

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ import models, schemas, auth_utils
 from database import SessionLocal, engine, get_db
 import uuid
 from datetime import timedelta
-from routers import auth, goals, transactions, recurring, debts, ai
+from routers import auth, goals, transactions, recurring, debts, ai, budgets
 
 models.Base.metadata.create_all(bind=engine)
 
@@ -29,6 +29,7 @@ app.include_router(transactions.router, prefix="/api", tags=["transactions"])
 app.include_router(recurring.router, prefix="/api", tags=["recurring"])
 app.include_router(debts.router, prefix="/api", tags=["debts"])
 app.include_router(ai.router, prefix="/api", tags=["ai"])
+app.include_router(budgets.router, prefix="/api", tags=["budgets"])
 
 from google.api_core.exceptions import ResourceExhausted
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -63,6 +63,14 @@ class Goal(Base):
     type = Column(String, default="savings") # 'savings' or 'investment'
     projectedReturnRate = Column(Float, default=0.0) # For investment goals
 
+class Budget(Base):
+    __tablename__ = "budgets"
+
+    id = Column(String, primary_key=True, index=True)
+    user_id = Column(String, ForeignKey("users.id"))
+    category = Column(String)
+    monthlyLimit = Column(Float)
+
 class User(Base):
     __tablename__ = "users"
 

--- a/backend/routers/budgets.py
+++ b/backend/routers/budgets.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+import models, schemas
+from database import get_db
+from .auth import get_current_user
+import uuid
+
+router = APIRouter()
+
+@router.get("/budgets", response_model=List[schemas.Budget])
+def read_budgets(db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
+    return db.query(models.Budget).filter(models.Budget.user_id == current_user.id).all()
+
+@router.post("/budgets", response_model=schemas.Budget)
+def create_budget(budget: schemas.BudgetCreate, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
+    existing = db.query(models.Budget).filter(
+        models.Budget.user_id == current_user.id,
+        models.Budget.category == budget.category
+    ).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="A budget for this category already exists")
+
+    db_budget = models.Budget(**budget.dict(), user_id=current_user.id)
+    if not db_budget.id:
+        db_budget.id = str(uuid.uuid4())
+    db.add(db_budget)
+    db.commit()
+    db.refresh(db_budget)
+    return db_budget
+
+@router.put("/budgets/{budget_id}", response_model=schemas.Budget)
+def update_budget(budget_id: str, budget: schemas.BudgetCreate, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
+    db_budget = db.query(models.Budget).filter(models.Budget.id == budget_id, models.Budget.user_id == current_user.id).first()
+    if not db_budget:
+        raise HTTPException(status_code=404, detail="Budget not found")
+
+    for key, value in budget.dict().items():
+        if key != 'id':
+            setattr(db_budget, key, value)
+
+    db.commit()
+    db.refresh(db_budget)
+    return db_budget
+
+@router.delete("/budgets/{budget_id}")
+def delete_budget(budget_id: str, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
+    db_budget = db.query(models.Budget).filter(models.Budget.id == budget_id, models.Budget.user_id == current_user.id).first()
+    if not db_budget:
+        raise HTTPException(status_code=404, detail="Budget not found")
+    db.delete(db_budget)
+    db.commit()
+    return {"ok": True}

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -104,3 +104,14 @@ class WishlistItemCreate(WishlistItemBase):
 class WishlistItem(WishlistItemBase):
     id: str
     model_config = ConfigDict(from_attributes=True)
+
+class BudgetBase(BaseModel):
+    category: str
+    monthlyLimit: float
+
+class BudgetCreate(BudgetBase):
+    id: Optional[str] = None
+
+class Budget(BudgetBase):
+    id: str
+    model_config = ConfigDict(from_attributes=True)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bufin",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import DashboardPage from './pages/DashboardPage';
 import LedgerPage from './pages/LedgerPage';
 import PlannerPage from './pages/PlannerPage';
 import GoalsPage from './pages/GoalsPage';
+import BudgetsPage from './pages/BudgetsPage';
 import InsightsPage from './pages/InsightsPage';
 import ProfilePage from './pages/ProfilePage';
 import CoachPage from './pages/CoachPage';
@@ -84,6 +85,7 @@ function App() {
         <Route path="/ledger" element={<ProtectedRoute><AppLayout><LedgerPage /></AppLayout></ProtectedRoute>} />
         <Route path="/planner" element={<ProtectedRoute><AppLayout><PlannerPage /></AppLayout></ProtectedRoute>} />
         <Route path="/goals" element={<ProtectedRoute><AppLayout><GoalsPage /></AppLayout></ProtectedRoute>} />
+        <Route path="/budgets" element={<ProtectedRoute><AppLayout><BudgetsPage /></AppLayout></ProtectedRoute>} />
         <Route path="/insights" element={<ProtectedRoute><AppLayout><InsightsPage /></AppLayout></ProtectedRoute>} />
         <Route path="/profile" element={<ProtectedRoute><AppLayout><ProfilePage /></AppLayout></ProtectedRoute>} />
         <Route path="/coach" element={<ProtectedRoute><AppLayout><CoachPage /></AppLayout></ProtectedRoute>} />

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -3,11 +3,78 @@ import { useNavigate } from 'react-router-dom';
 import { useFinancial } from '../context/FinancialContext';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
-import { TrendingUp, TrendingDown, Wallet, Trash2 } from 'lucide-react';
+import { TrendingUp, TrendingDown, Wallet, Trash2, Wallet2 } from 'lucide-react';
 import JargonBuster from './JargonBuster';
 import { Button } from './ui/button';
 import EmptyState from './EmptyState';
 import { Skeleton } from './ui/skeleton';
+import { ThresholdProgress } from './ui/progress';
+
+export const BudgetSummaryCard = () => {
+    const { budgets, transactions, isDataLoading } = useFinancial();
+    const navigate = useNavigate();
+
+    const now = new Date();
+    const withSpend = budgets.map(b => {
+        const spent = transactions
+            .filter(t => {
+                if (t.type !== 'expense' || t.category !== b.category) return false;
+                const d = new Date(t.date);
+                return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear();
+            })
+            .reduce((acc, t) => acc + t.amount, 0);
+        return { ...b, spent, pct: b.monthlyLimit > 0 ? (spent / b.monthlyLimit) * 100 : 0 };
+    });
+
+    const overBudget = withSpend.filter(b => b.pct >= 100).sort((a, b) => b.pct - a.pct);
+
+    if (isDataLoading) {
+        return (
+            <Card className="h-full shadow-sm">
+                <CardHeader className="pb-2">
+                    <CardTitle className="text-sm font-medium">Budgets</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                    <Skeleton className="h-4 w-3/4" />
+                    <Skeleton className="h-4 w-1/2" />
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card className="h-full shadow-sm cursor-pointer hover:bg-primary/5 transition-colors" onClick={() => navigate('/budgets')}>
+            <CardHeader className="pb-2 flex flex-row items-center justify-between">
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                    <Wallet2 className="h-4 w-4 text-muted-foreground" />
+                    Budgets
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                {budgets.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">No budgets set — tap to add category limits.</p>
+                ) : overBudget.length === 0 ? (
+                    <p className="text-sm text-emerald-600 dark:text-emerald-400 font-medium">All {budgets.length} categories on track this month.</p>
+                ) : (
+                    <div className="space-y-2">
+                        <p className="text-xs text-muted-foreground">
+                            {overBudget.length} of {budgets.length} categor{overBudget.length === 1 ? 'y' : 'ies'} over budget
+                        </p>
+                        {overBudget.slice(0, 2).map(b => (
+                            <div key={b.id} className="space-y-1">
+                                <div className="flex justify-between text-xs">
+                                    <span className="font-medium">{b.category}</span>
+                                    <span className="text-red-500">{Math.round(b.pct)}%</span>
+                                </div>
+                                <ThresholdProgress value={b.pct} className="h-2" />
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+};
 
 export const FinancialSummaryCard = () => {
     const { balance, income, expense, isDataLoading } = useFinancial();

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { LayoutDashboard, FileText, Calendar, PieChart, MessageSquareText, LogOut, Settings, User, Target, Wallet } from 'lucide-react';
+import { LayoutDashboard, FileText, Calendar, PieChart, MessageSquareText, LogOut, Settings, User, Target, Wallet, Wallet2 } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { useAuth } from '../context/AuthContext';
 import { Button } from './ui/button';
@@ -14,6 +14,7 @@ const Navigation = () => {
         { name: 'Ledger', path: '/ledger', icon: FileText },
         { name: 'Planner', path: '/planner', icon: Calendar },
         { name: 'Goals', path: '/goals', icon: Target },
+        { name: 'Budgets', path: '/budgets', icon: Wallet2 },
         { name: 'Insights', path: '/insights', icon: PieChart },
         { name: 'Coach', path: '/coach', icon: MessageSquareText },
     ];

--- a/src/components/ui/progress.jsx
+++ b/src/components/ui/progress.jsx
@@ -18,4 +18,27 @@ const Progress = React.forwardRef(({ className, value, ...props }, ref) => (
 ));
 Progress.displayName = "Progress";
 
-export { Progress };
+// Same visual shape as Progress, but the fill color shifts green -> amber -> red as `value`
+// (0-100, uncapped) approaches/exceeds 100. Used for budget-vs-actual and similar limit bars.
+const ThresholdProgress = React.forwardRef(({ className, value = 0, ...props }, ref) => {
+    const pct = Math.max(0, value);
+    const colorClass = pct >= 100 ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-emerald-500';
+    return (
+        <div
+            ref={ref}
+            className={cn(
+                "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+                className
+            )}
+            {...props}
+        >
+            <div
+                className={cn("h-full flex-1 transition-all", colorClass)}
+                style={{ width: `${Math.min(100, pct)}%` }}
+            />
+        </div>
+    );
+});
+ThresholdProgress.displayName = "ThresholdProgress";
+
+export { Progress, ThresholdProgress };

--- a/src/context/FinancialContext.jsx
+++ b/src/context/FinancialContext.jsx
@@ -22,6 +22,7 @@ export const FinancialProvider = ({ children }) => {
   const [transactions, setTransactions] = useState([]);
   const [recurringPlans, setRecurringPlans] = useState([]);
   const [debts, setDebts] = useState([]);
+  const [budgets, setBudgets] = useState([]);
   const repayingDebtIds = useRef(new Set());
 
   const [wishlist, setWishlist] = useState([]);
@@ -59,18 +60,20 @@ export const FinancialProvider = ({ children }) => {
     const fetchData = async () => {
       setIsDataLoading(true);
       try {
-        const [txs, plans, dbt, wish, goals] = await Promise.all([
+        const [txs, plans, dbt, wish, goals, budgetList] = await Promise.all([
           api.getTransactions(),
           api.getRecurringPlans(),
           api.getDebts(),
           api.getWishlist(),
-          api.getGoals()
+          api.getGoals(),
+          api.getBudgets()
         ]);
         setTransactions(txs);
         setRecurringPlans(plans);
         setDebts(dbt);
         setWishlist(wish);
         setSavingsGoals(goals);
+        setBudgets(budgetList);
       } catch (error) {
         console.error("Failed to fetch initial data:", error);
         toast({
@@ -230,6 +233,41 @@ export const FinancialProvider = ({ children }) => {
       setDebts(prev => prev.filter(d => d.id !== id));
     } catch (error) {
       console.error("Failed to delete debt:", error);
+    }
+  };
+
+  const addBudget = async (budget) => {
+    try {
+      const newBudget = await api.createBudget(budget);
+      setBudgets(prev => [...prev, newBudget]);
+    } catch (error) {
+      console.error("Failed to add budget:", error);
+      toast({
+        title: 'Could not save budget',
+        description: error.message === 'Failed to create budget'
+          ? 'You may already have a budget set for this category.'
+          : 'Please try again.',
+        variant: 'destructive'
+      });
+    }
+  };
+
+  const updateBudget = async (id, updatedBudget) => {
+    try {
+      const updated = await api.updateBudget(id, updatedBudget);
+      setBudgets(prev => prev.map(b => b.id === id ? updated : b));
+    } catch (error) {
+      console.error("Failed to update budget:", error);
+      toast({ title: 'Could not update budget', variant: 'destructive' });
+    }
+  };
+
+  const deleteBudget = async (id) => {
+    try {
+      await api.deleteBudget(id);
+      setBudgets(prev => prev.filter(b => b.id !== id));
+    } catch (error) {
+      console.error("Failed to delete budget:", error);
     }
   };
 
@@ -429,6 +467,10 @@ export const FinancialProvider = ({ children }) => {
       updateDebt,
       deleteDebt,
       repayDebt,
+      budgets,
+      addBudget,
+      updateBudget,
+      deleteBudget,
       updateRecurringPlan,
       deleteRecurringPlan,
       wishlist,

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -215,6 +215,51 @@ export const api = {
         if (!response.ok) throw new Error('Failed to update debt');
         return response.json();
     },
+    getBudgets: async () => {
+        const token = localStorage.getItem('token');
+        const headers = token ? { 'Authorization': `Bearer ${token}` } : {};
+        const response = await fetch(`${API_URL}/budgets`, { headers });
+        if (!response.ok) throw new Error('Failed to fetch budgets');
+        return response.json();
+    },
+    createBudget: async (budget) => {
+        const token = localStorage.getItem('token');
+        const headers = {
+            'Content-Type': 'application/json',
+            ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+        };
+        const response = await fetch(`${API_URL}/budgets`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(budget),
+        });
+        if (!response.ok) throw new Error('Failed to create budget');
+        return response.json();
+    },
+    updateBudget: async (id, budget) => {
+        const token = localStorage.getItem('token');
+        const headers = {
+            'Content-Type': 'application/json',
+            ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+        };
+        const response = await fetch(`${API_URL}/budgets/${id}`, {
+            method: 'PUT',
+            headers,
+            body: JSON.stringify(budget),
+        });
+        if (!response.ok) throw new Error('Failed to update budget');
+        return response.json();
+    },
+    deleteBudget: async (id) => {
+        const token = localStorage.getItem('token');
+        const headers = token ? { 'Authorization': `Bearer ${token}` } : {};
+        const response = await fetch(`${API_URL}/budgets/${id}`, {
+            method: 'DELETE',
+            headers
+        });
+        if (!response.ok) throw new Error('Failed to delete budget');
+        return response.json();
+    },
 
     // Goals
     getGoals: async () => {

--- a/src/pages/BudgetsPage.jsx
+++ b/src/pages/BudgetsPage.jsx
@@ -1,0 +1,168 @@
+import React, { useState } from 'react';
+import { useFinancial } from '../context/FinancialContext';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
+import { ThresholdProgress } from '../components/ui/progress';
+import { Trash2, Plus, Wallet2 } from 'lucide-react';
+import EmptyState from '../components/EmptyState';
+
+const BudgetsPage = () => {
+    const { budgets, addBudget, updateBudget, deleteBudget, transactions, categories, isPrivacyMode } = useFinancial();
+    const [newCategory, setNewCategory] = useState('');
+    const [newLimit, setNewLimit] = useState('');
+    const [editingId, setEditingId] = useState(null);
+    const [editingValue, setEditingValue] = useState('');
+
+    const budgetedCategories = new Set(budgets.map(b => b.category));
+    const availableCategories = categories.filter(c => !budgetedCategories.has(c));
+
+    const now = new Date();
+    const spentByCategory = transactions.reduce((acc, t) => {
+        if (t.type !== 'expense') return acc;
+        const d = new Date(t.date);
+        if (d.getMonth() !== now.getMonth() || d.getFullYear() !== now.getFullYear()) return acc;
+        acc[t.category] = (acc[t.category] || 0) + t.amount;
+        return acc;
+    }, {});
+
+    const formatCurrency = (amount) => {
+        if (isPrivacyMode) return '••••••';
+        return `₹${amount.toFixed(0)}`;
+    };
+
+    const handleAdd = (e) => {
+        e.preventDefault();
+        const limit = parseFloat(newLimit);
+        if (!newCategory || !limit || limit <= 0) return;
+        addBudget({ category: newCategory, monthlyLimit: limit });
+        setNewCategory('');
+        setNewLimit('');
+    };
+
+    const startEditing = (budget) => {
+        setEditingId(budget.id);
+        setEditingValue(String(budget.monthlyLimit));
+    };
+
+    const saveEditing = (budget) => {
+        const limit = parseFloat(editingValue);
+        if (limit > 0) {
+            updateBudget(budget.id, { category: budget.category, monthlyLimit: limit });
+        }
+        setEditingId(null);
+    };
+
+    return (
+        <div className="space-y-6">
+            <div className="pb-2">
+                <h1 className="text-3xl font-bold tracking-tight text-primary">Budgets</h1>
+                <p className="text-muted-foreground mt-1">Set a monthly limit per category and track actual spend against it.</p>
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Add a Budget</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <form onSubmit={handleAdd} className="flex flex-col sm:flex-row gap-3">
+                        <Select value={newCategory} onValueChange={setNewCategory} className="sm:w-56">
+                            <SelectTrigger>
+                                <SelectValue placeholder="Select category" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {availableCategories.map(c => (
+                                    <SelectItem key={c} value={c}>{c}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <Input
+                            type="number"
+                            min="1"
+                            step="1"
+                            placeholder="Monthly limit (₹)"
+                            value={newLimit}
+                            onChange={(e) => setNewLimit(e.target.value)}
+                            className="sm:w-48"
+                        />
+                        <Button type="submit" disabled={!newCategory || !newLimit}>
+                            <Plus className="mr-2 h-4 w-4" />
+                            Add Budget
+                        </Button>
+                    </form>
+                    {availableCategories.length === 0 && budgets.length > 0 && (
+                        <p className="text-xs text-muted-foreground mt-2">Every category already has a budget.</p>
+                    )}
+                </CardContent>
+            </Card>
+
+            {budgets.length === 0 ? (
+                <EmptyState
+                    icon={Wallet2}
+                    title="No budgets set yet"
+                    description="Pick a category above and set a monthly limit to start tracking budget-vs-actual."
+                />
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {budgets.map((budget) => {
+                        const spent = spentByCategory[budget.category] || 0;
+                        const pct = budget.monthlyLimit > 0 ? (spent / budget.monthlyLimit) * 100 : 0;
+                        const isEditing = editingId === budget.id;
+
+                        return (
+                            <Card key={budget.id} className="shadow-sm">
+                                <CardContent className="p-5 space-y-3">
+                                    <div className="flex items-center justify-between">
+                                        <span className="font-semibold text-foreground">{budget.category}</span>
+                                        <div className="flex items-center gap-2">
+                                            {isEditing ? (
+                                                <Input
+                                                    type="number"
+                                                    autoFocus
+                                                    value={editingValue}
+                                                    onChange={(e) => setEditingValue(e.target.value)}
+                                                    onBlur={() => saveEditing(budget)}
+                                                    onKeyDown={(e) => e.key === 'Enter' && saveEditing(budget)}
+                                                    className="h-8 w-24 text-right"
+                                                />
+                                            ) : (
+                                                <button
+                                                    onClick={() => startEditing(budget)}
+                                                    className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                                                    title="Click to edit limit"
+                                                >
+                                                    of {formatCurrency(budget.monthlyLimit)}
+                                                </button>
+                                            )}
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="h-7 w-7 text-muted-foreground hover:text-red-500"
+                                                onClick={() => deleteBudget(budget.id)}
+                                                title="Delete budget"
+                                            >
+                                                <Trash2 className="h-3.5 w-3.5" />
+                                            </Button>
+                                        </div>
+                                    </div>
+
+                                    <ThresholdProgress value={pct} />
+
+                                    <div className="flex items-center justify-between text-xs">
+                                        <span className={pct >= 100 ? 'text-red-500 font-medium' : 'text-muted-foreground'}>
+                                            {formatCurrency(spent)} spent this month
+                                        </span>
+                                        <span className="text-muted-foreground">{Math.round(pct)}%</span>
+                                    </div>
+                                </CardContent>
+                            </Card>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default BudgetsPage;

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useAuth } from '../context/AuthContext';
-import { FinancialSummaryCard, ExpenseBreakdown, RecentTransactions } from '../components/Dashboard';
+import { FinancialSummaryCard, ExpenseBreakdown, RecentTransactions, BudgetSummaryCard } from '../components/Dashboard';
 import NaturalLanguageInput from '../components/NaturalLanguageInput';
 import BudgetHealthBar from '../components/BudgetHealthBar';
 import PurchaseSimulator from '../components/PurchaseSimulator';
@@ -42,12 +42,15 @@ const DashboardPage = () => {
                     <SpendingMonitor />
                 </div>
 
-                {/* Row 3: Financial Summary (2) & Simulator (5) */}
+                {/* Row 3: Financial Summary (2), Budget Summary (2) & Simulator (3) */}
                 <div className="md:col-span-4 grid grid-cols-1 md:grid-cols-7 gap-3">
                     <div className="md:col-span-2">
                         <FinancialSummaryCard />
                     </div>
-                    <div className="md:col-span-5">
+                    <div className="md:col-span-2">
+                        <BudgetSummaryCard />
+                    </div>
+                    <div className="md:col-span-3">
                         <PurchaseSimulator />
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
Adds per-category monthly budgets with budget-vs-actual tracking, closing the "explicit budgets" gap from the UX research. Bank/CSV import (the original Phase 3) is deferred per current priority - this phase was promoted since budgets work fine against existing manually-entered, categorized transactions.

- New `Budget` model/schema/CRUD endpoints (`/api/budgets`), one budget per category per user, with an Alembic migration.
- Budgets wired into `FinancialContext` (state + CRUD actions + error toasts on save failure).
- New `ThresholdProgress` UI primitive - same shape as the existing `Progress` bar, but fills green/amber/red based on how close `value` is to 100.
- New `/budgets` page: set a category + monthly limit, see actual spend this month against it with the threshold-colored bar, inline-edit the limit, delete.
- Dashboard gets a compact `BudgetSummaryCard` widget showing at-a-glance how many categories are over budget this month, linking to the full page.
- Version bumped to 1.2.0.

## Test plan
- [x] `npm run build` succeeds, backend imports cleanly, budgets routes register correctly (verified locally)
- [x] Verified the migration's raw DDL is valid SQLite (verified locally against a scratch db)
- [x] Manually create a budget for a category with existing spend this month and confirm the progress bar/percentage are correct
- [x] Manually confirm creating a second budget for the same category is rejected (backend returns 400, should surface as a toast)
- [x] Manually confirm the Dashboard widget updates when a category goes over budget