### PR TITLE
Phase 4: Design system upgrade

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ from routers import auth, goals, transactions, recurring, debts, ai, budgets
 
 models.Base.metadata.create_all(bind=engine)
 
-app = FastAPI(title="BuFin API", version="1.2.0")
+app = FastAPI(title="BuFin API", version="1.3.0")
 
 # CORS Middleware
 app.add_middleware(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bufin",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/BudgetHealthBar.jsx
+++ b/src/components/BudgetHealthBar.jsx
@@ -79,7 +79,7 @@ const BudgetHealthBar = () => {
                     </div>
 
                     {wantsPct > 30 && (
-                        <p className="text-xs text-red-500 font-medium">
+                        <p className="text-xs text-destructive font-medium">
                             Warning: Your "Wants" exceed 30% of your income!
                         </p>
                     )}

--- a/src/components/CashFlowForecast.jsx
+++ b/src/components/CashFlowForecast.jsx
@@ -115,12 +115,12 @@ const CashFlowForecast = () => {
                                 style={{ bottom: `${heightPct}%` }}
                             >
                                 <div className="font-semibold mb-0.5">{format(week.weekStart, 'MMM d')} - {format(addDays(week.weekStart, 6), 'MMM d')}</div>
-                                <div className={`text-xs font-bold ${week.balance < 0 ? 'text-red-500' : 'text-primary'}`}>
+                                <div className={`text-xs font-bold tabular-nums ${week.balance < 0 ? 'text-destructive' : 'text-primary'}`}>
                                     {isPrivacyMode ? '••••' : `₹${week.balance.toLocaleString()}`}
                                 </div>
-                                <div className="text-muted-foreground mt-0.5 flex gap-2">
-                                    <span className="text-green-500">+{isPrivacyMode ? '••' : (week.income / 1000).toFixed(1)}k</span>
-                                    <span className="text-red-500">-{isPrivacyMode ? '••' : (week.expense / 1000).toFixed(1)}k</span>
+                                <div className="text-muted-foreground mt-0.5 flex gap-2 tabular-nums">
+                                    <span className="text-success">+{isPrivacyMode ? '••' : (week.income / 1000).toFixed(1)}k</span>
+                                    <span className="text-destructive">-{isPrivacyMode ? '••' : (week.expense / 1000).toFixed(1)}k</span>
                                 </div>
                                 {/* Tooltip Arrow */}
                                 <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-2 h-2 bg-popover/95 border-r border-b border-border/50 rotate-45"></div>
@@ -128,10 +128,10 @@ const CashFlowForecast = () => {
 
                             {/* Bar */}
                             <div
-                                className={`w-full rounded-t-lg transition-all duration-500 relative overflow-hidden ${week.balance < 0 ? 'bg-gradient-to-t from-red-500/80 to-red-400' :
-                                        week.isDanger ? 'bg-gradient-to-t from-yellow-500/80 to-yellow-400' :
+                                className={`w-full rounded-t-lg transition-all duration-slow relative overflow-hidden ${week.balance < 0 ? 'bg-gradient-to-t from-destructive/80 to-destructive/60' :
+                                        week.isDanger ? 'bg-gradient-to-t from-warning/80 to-warning/60' :
                                             'bg-gradient-to-t from-primary/80 to-primary/40'
-                                    } group-hover:brightness-110 group-hover:shadow-[0_0_15px_rgba(var(--primary),0.3)]`}
+                                    } group-hover:brightness-110`}
                                 style={{ height: `${heightPct}%` }}
                             >
                                 {/* Shine Effect */}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -9,6 +9,7 @@ import { Button } from './ui/button';
 import EmptyState from './EmptyState';
 import { Skeleton } from './ui/skeleton';
 import { ThresholdProgress } from './ui/progress';
+import { CHART_COLORS, chartTooltipStyle } from '../lib/chartTheme';
 
 export const BudgetSummaryCard = () => {
     const { budgets, transactions, isDataLoading } = useFinancial();
@@ -150,8 +151,6 @@ export const ExpenseBreakdown = () => {
             return acc;
         }, []);
 
-    const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884d8'];
-
     return (
         <Card className="h-full flex flex-col shadow-sm">
             <CardHeader className="pb-2 pt-4 px-5">
@@ -172,16 +171,15 @@ export const ExpenseBreakdown = () => {
                                     cy="50%"
                                     innerRadius={50}
                                     outerRadius={70}
-                                    fill="#8884d8"
                                     paddingAngle={5}
                                     dataKey="value"
                                 >
                                     {chartData.map((entry, index) => (
-                                        <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                                        <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
                                     ))}
                                 </Pie>
-                                <Tooltip />
-                                <Legend verticalAlign="middle" align="right" layout="vertical" iconSize={8} wrapperStyle={{ fontSize: '10px' }} />
+                                <Tooltip contentStyle={chartTooltipStyle} />
+                                <Legend verticalAlign="middle" align="right" layout="vertical" iconSize={8} wrapperStyle={{ fontSize: '10px', color: 'var(--foreground)' }} />
                             </PieChart>
                         </ResponsiveContainer>
                     </div>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -54,7 +54,7 @@ export const BudgetSummaryCard = () => {
                 {budgets.length === 0 ? (
                     <p className="text-xs text-muted-foreground">No budgets set — tap to add category limits.</p>
                 ) : overBudget.length === 0 ? (
-                    <p className="text-sm text-emerald-600 dark:text-emerald-400 font-medium">All {budgets.length} categories on track this month.</p>
+                    <p className="text-sm text-success font-medium">All {budgets.length} categories on track this month.</p>
                 ) : (
                     <div className="space-y-2">
                         <p className="text-xs text-muted-foreground">
@@ -64,7 +64,7 @@ export const BudgetSummaryCard = () => {
                             <div key={b.id} className="space-y-1">
                                 <div className="flex justify-between text-xs">
                                     <span className="font-medium">{b.category}</span>
-                                    <span className="text-red-500">{Math.round(b.pct)}%</span>
+                                    <span className="text-destructive tabular-nums">{Math.round(b.pct)}%</span>
                                 </div>
                                 <ThresholdProgress value={b.pct} className="h-2" />
                             </div>
@@ -105,30 +105,30 @@ export const FinancialSummaryCard = () => {
                         <span className="text-xs font-semibold uppercase tracking-wider">Net Balance</span>
                         <Wallet className="h-3.5 w-3.5" />
                     </div>
-                    <div className="text-3xl font-bold tracking-tight">₹{balance.toFixed(0)}</div>
+                    <div className="text-3xl font-bold tracking-tight tabular-nums">₹{balance.toFixed(0)}</div>
                 </div>
 
                 <div className="grid grid-cols-2 gap-4 pt-4 border-t border-border/50">
                     {/* Income */}
                     <div className="space-y-1">
                         <div className="flex items-center gap-1.5 text-muted-foreground">
-                            <div className="p-1 rounded-full bg-green-500/10">
-                                <TrendingUp className="h-3 w-3 text-green-600" />
+                            <div className="p-1 rounded-full bg-success/10">
+                                <TrendingUp className="h-3 w-3 text-success" />
                             </div>
                             <span className="text-[10px] font-semibold uppercase">Income</span>
                         </div>
-                        <div className="text-lg font-semibold text-green-600 dark:text-green-400">+₹{income.toFixed(0)}</div>
+                        <div className="text-lg font-semibold text-success tabular-nums">+₹{income.toFixed(0)}</div>
                     </div>
 
                     {/* Expenses */}
                     <div className="space-y-1">
                         <div className="flex items-center gap-1.5 text-muted-foreground">
-                            <div className="p-1 rounded-full bg-red-500/10">
-                                <TrendingDown className="h-3 w-3 text-red-600" />
+                            <div className="p-1 rounded-full bg-destructive/10">
+                                <TrendingDown className="h-3 w-3 text-destructive" />
                             </div>
                             <span className="text-[10px] font-semibold uppercase">Expense</span>
                         </div>
-                        <div className="text-lg font-semibold text-red-600 dark:text-red-400">-₹{expense.toFixed(0)}</div>
+                        <div className="text-lg font-semibold text-destructive tabular-nums">-₹{expense.toFixed(0)}</div>
                     </div>
                 </div>
             </CardContent>
@@ -250,13 +250,13 @@ export const RecentTransactions = () => {
                                 <p className="text-xs text-muted-foreground truncate font-medium">{t.description || t.merchant}</p>
                             </div>
                             <div className="flex items-center gap-3 pl-2 shrink-0">
-                                <div className={`font-bold text-sm ${t.type === 'income' ? 'text-green-600' : 'text-red-600'}`}>
+                                <div className={`font-bold text-sm tabular-nums ${t.type === 'income' ? 'text-success' : 'text-destructive'}`}>
                                     {t.type === 'income' ? '+' : '-'}₹{t.amount.toFixed(0)}
                                 </div>
                                 <Button
                                     variant="ghost"
                                     size="icon"
-                                    className="h-6 w-6 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity hover:text-red-500 hover:bg-red-50"
+                                    className="h-6 w-6 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity hover:text-destructive hover:bg-destructive/10"
                                     onClick={() => deleteTransaction(t.id)}
                                 >
                                     <Trash2 className="h-3.5 w-3.5" />

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -82,7 +82,7 @@ export const FinancialSummaryCard = () => {
 
     if (isDataLoading) {
         return (
-            <Card className="h-full border-none shadow-lg rounded-2xl">
+            <Card className="h-full">
                 <CardContent className="h-full flex flex-col justify-between p-5">
                     <div className="space-y-2">
                         <Skeleton className="h-3 w-24" />
@@ -98,7 +98,7 @@ export const FinancialSummaryCard = () => {
     }
 
     return (
-        <Card className="h-full border-none shadow-lg rounded-2xl hover:shadow-xl transition-shadow">
+        <Card className="h-full">
             <CardContent className="h-full flex flex-col justify-between p-5">
                 {/* Balance */}
                 <div className="space-y-1">

--- a/src/components/DebtTracker.jsx
+++ b/src/components/DebtTracker.jsx
@@ -36,7 +36,7 @@ const DebtTracker = ({ compact }) => {
                 activeDebts.map(debt => (
                     <div key={debt.id} className="flex items-center justify-between border-b pb-2 last:border-0 group">
                         <div className="flex items-center gap-3">
-                            <div className={`p-2 rounded-full ${debt.direction === 'receivable' ? 'bg-green-100 text-green-600' : 'bg-red-100 text-red-600'}`}>
+                            <div className={`p-2 rounded-full ${debt.direction === 'receivable' ? 'bg-success/10 text-success' : 'bg-destructive/10 text-destructive'}`}>
                                 {debt.direction === 'receivable' ? <ArrowDownLeft className="h-4 w-4" /> : <ArrowUpRight className="h-4 w-4" />}
                             </div>
                             <div>
@@ -45,7 +45,7 @@ const DebtTracker = ({ compact }) => {
                             </div>
                         </div>
                         <div className="flex items-center gap-3">
-                            <div className={`font-bold whitespace-nowrap ${debt.direction === 'receivable' ? 'text-green-600' : 'text-red-600'}`}>
+                            <div className={`font-bold whitespace-nowrap tabular-nums ${debt.direction === 'receivable' ? 'text-success' : 'text-destructive'}`}>
                                 {formatCurrency(debt.amount)}
                             </div>
                             <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -53,7 +53,7 @@ const DebtTracker = ({ compact }) => {
                                     <Button
                                         variant="ghost"
                                         size="icon"
-                                        className={`h-7 w-7 ${debt.direction === 'receivable' ? 'text-green-600 hover:text-green-700 hover:bg-green-50' : 'text-red-600 hover:text-red-700 hover:bg-red-50'}`}
+                                        className={`h-7 w-7 ${debt.direction === 'receivable' ? 'text-success hover:bg-success/10' : 'text-destructive hover:bg-destructive/10'}`}
                                         title={debt.direction === 'receivable' ? "Mark as Received" : "Mark as Repaid"}
                                         onClick={() => repayDebt(debt.id)}
                                     >
@@ -71,7 +71,7 @@ const DebtTracker = ({ compact }) => {
                                 <Button
                                     variant="ghost"
                                     size="icon"
-                                    className="h-7 w-7 text-muted-foreground hover:text-red-600 hover:bg-red-50"
+                                    className="h-7 w-7 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
                                     onClick={() => deleteDebt(debt.id)}
                                 >
                                     <Trash2 className="h-4 w-4" />

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -18,23 +18,23 @@ class ErrorBoundary extends React.Component {
     render() {
         if (this.state.hasError) {
             return (
-                <div className="min-h-screen flex items-center justify-center bg-red-50 p-4">
-                    <div className="max-w-2xl w-full bg-white rounded-lg shadow-lg p-8 border border-red-200">
-                        <h1 className="text-2xl font-bold text-red-700 mb-4">Something went wrong.</h1>
-                        <p className="text-gray-600 mb-4">The application encountered a critical error and could not render.</p>
+                <div className="min-h-screen flex items-center justify-center bg-background p-4">
+                    <div className="max-w-2xl w-full bg-card text-card-foreground rounded-lg shadow-lg p-8 border border-destructive/30">
+                        <h1 className="text-2xl font-bold text-destructive mb-4">Something went wrong.</h1>
+                        <p className="text-muted-foreground mb-4">The application encountered a critical error and could not render.</p>
 
-                        <div className="bg-gray-100 p-4 rounded overflow-auto max-h-64 mb-6">
-                            <code className="text-sm text-red-600 font-mono block mb-2">
+                        <div className="bg-secondary p-4 rounded-md overflow-auto max-h-64 mb-6">
+                            <code className="text-sm text-destructive font-mono block mb-2">
                                 {this.state.error && this.state.error.toString()}
                             </code>
-                            <pre className="text-xs text-gray-500 font-mono">
+                            <pre className="text-xs text-muted-foreground font-mono">
                                 {this.state.errorInfo && this.state.errorInfo.componentStack}
                             </pre>
                         </div>
 
                         <button
                             onClick={() => window.location.reload()}
-                            className="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded transition-colors"
+                            className="bg-destructive hover:bg-destructive/90 text-destructive-foreground font-bold py-2 px-4 rounded-lg transition-colors duration-fast"
                         >
                             Reload Application
                         </button>

--- a/src/components/FiscalCalendar.jsx
+++ b/src/components/FiscalCalendar.jsx
@@ -165,8 +165,8 @@ const FiscalCalendar = () => {
                                                 className={cn(
                                                     "text-[10px] px-1 py-0.5 rounded truncate flex justify-between items-center flex-shrink-0",
                                                     item.type === 'income'
-                                                        ? "bg-green-500/10 text-green-700 dark:text-green-400"
-                                                        : "bg-red-500/10 text-red-700 dark:text-red-400"
+                                                        ? "bg-success/10 text-success"
+                                                        : "bg-destructive/10 text-destructive"
                                                 )}
                                                 title={`${item.name} - ₹${item.amount}`}
                                             >
@@ -211,8 +211,8 @@ const FiscalCalendar = () => {
                                         </div>
                                     </div>
                                     <span className={cn(
-                                        "font-bold text-sm",
-                                        item.type === 'income' ? "text-green-600" : "text-red-600"
+                                        "font-bold text-sm tabular-nums",
+                                        item.type === 'income' ? "text-success" : "text-destructive"
                                     )}>
                                         {item.type === 'income' ? '+' : '-'}₹{item.amount.toFixed(2)}
                                     </span>

--- a/src/components/FutureTransactions.jsx
+++ b/src/components/FutureTransactions.jsx
@@ -53,7 +53,7 @@ const FutureTransactions = () => {
                     {futureTransactions.map(t => (
                         <div key={t.id} className="flex items-center justify-between p-3 bg-secondary/30 rounded-xl hover:bg-secondary/50 transition-colors group">
                             <div className="flex items-center gap-3">
-                                <div className={`p-2 rounded-full ${t.type === 'income' ? 'bg-emerald-100 text-emerald-600' : 'bg-rose-100 text-rose-600'}`}>
+                                <div className={`p-2 rounded-full ${t.type === 'income' ? 'bg-success/10 text-success' : 'bg-destructive/10 text-destructive'}`}>
                                     {t.type === 'income' ? <ArrowDownLeft className="h-4 w-4" /> : <ArrowUpRight className="h-4 w-4" />}
                                 </div>
                                 <div>
@@ -62,7 +62,7 @@ const FutureTransactions = () => {
                                 </div>
                             </div>
                             <div className="flex items-center gap-3">
-                                <div className={`font-semibold text-sm ${t.type === 'income' ? 'text-emerald-600' : 'text-rose-600'}`}>
+                                <div className={`font-semibold text-sm tabular-nums ${t.type === 'income' ? 'text-success' : 'text-destructive'}`}>
                                     {t.type === 'income' ? '+' : '-'}₹{t.amount.toLocaleString()}
                                 </div>
                                 <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -78,7 +78,7 @@ const FutureTransactions = () => {
                                     <Button
                                         variant="ghost"
                                         size="icon"
-                                        className="h-7 w-7 text-muted-foreground hover:text-red-500"
+                                        className="h-7 w-7 text-muted-foreground hover:text-destructive"
                                         onClick={(e) => { e.stopPropagation(); deleteTransaction(t.id); }}
                                         title="Delete"
                                     >

--- a/src/components/ImpulseControl.jsx
+++ b/src/components/ImpulseControl.jsx
@@ -123,7 +123,7 @@ const ImpulseControl = () => {
                                             </div>
                                             <div className="text-right">
                                                 {isExpired ? (
-                                                    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                                                    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-success/10 text-success">
                                                         Ready
                                                     </span>
                                                 ) : (
@@ -157,7 +157,7 @@ const ImpulseControl = () => {
                                                 <Button
                                                     variant="ghost"
                                                     size="sm"
-                                                    className="w-full h-8 text-xs text-muted-foreground hover:text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20"
+                                                    className="w-full h-8 text-xs text-muted-foreground hover:text-success hover:bg-success/10"
                                                     onClick={() => handleRemoved(item)}
                                                 >
                                                     <XCircle className="h-3 w-3 mr-1" /> Don't Buy (Savings Win)

--- a/src/components/InsightsDashboard.jsx
+++ b/src/components/InsightsDashboard.jsx
@@ -153,7 +153,7 @@ const InsightsDashboard = () => {
                                         Detected Potential Subscriptions
                                     </div>
                                     {subscriptions.map((sub, index) => (
-                                        <div key={`new- ${index} `} className="flex items-center justify-between p-3 bg-yellow-500/10 rounded-lg border border-yellow-500/20 group">
+                                        <div key={`new- ${index} `} className="flex items-center justify-between p-3 bg-warning/10 rounded-lg border border-warning/20 group">
                                             <div>
                                                 <p className="font-medium text-foreground">{sub.name}</p>
                                                 <p className="text-xs text-muted-foreground">
@@ -161,12 +161,12 @@ const InsightsDashboard = () => {
                                                 </p>
                                             </div>
                                             <div className="flex items-center gap-3">
-                                                <div className="font-bold text-yellow-600">₹{sub.amount.toFixed(2)}</div>
+                                                <div className="font-bold text-warning tabular-nums">₹{sub.amount.toFixed(2)}</div>
                                                 <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                                                     <Button
                                                         variant="ghost"
                                                         size="icon"
-                                                        className="h-7 w-7 text-green-600 hover:bg-green-100"
+                                                        className="h-7 w-7 text-success hover:bg-success/10"
                                                         onClick={() => handleAddSubscription(sub)}
                                                         title="Add to Planner"
                                                     >

--- a/src/components/InsightsWidgets.jsx
+++ b/src/components/InsightsWidgets.jsx
@@ -62,7 +62,7 @@ export const SpendingComparisonWidget = () => {
                         <div key={item.category} className="space-y-1">
                             <div className="flex justify-between text-sm">
                                 <span className="font-medium">{item.category}</span>
-                                <span className={item.diff > 0 ? "text-red-500" : "text-green-500"}>
+                                <span className={item.diff > 0 ? "text-destructive" : "text-success"}>
                                     {item.diff > 0 ? `+${item.percent}% higher` : `${Math.abs(item.percent)}% lower`}
                                 </span>
                             </div>

--- a/src/components/JarVisualization.jsx
+++ b/src/components/JarVisualization.jsx
@@ -54,8 +54,8 @@ const JarVisualization = ({ goal, onEdit }) => {
 
     return (
         <Card className={cn(
-            "relative overflow-hidden transition-all duration-500 hover:shadow-xl border-2",
-            isCompleted ? "border-green-400 bg-green-50/30 dark:bg-green-900/10" :
+            "relative overflow-hidden transition-colors duration-normal hover:shadow-xl border-2",
+            isCompleted ? "border-success bg-success/10" :
                 "border-border/60 hover:border-primary/50 bg-card"
         )}>
 
@@ -63,11 +63,11 @@ const JarVisualization = ({ goal, onEdit }) => {
             <CardContent className="p-0 h-full flex flex-col">
                 <div className="flex flex-1 p-5 gap-4">
                     {/* Vertical Liquid Progress */}
-                    <div className="relative w-16 bg-secondary/50 rounded-2xl overflow-hidden flex-shrink-0 border border-border/50">
+                    <div className="relative w-16 bg-secondary/50 rounded-lg overflow-hidden flex-shrink-0 border border-border/50">
                         <div
                             className={cn(
-                                "absolute bottom-0 left-0 right-0 transition-all duration-1000 ease-out",
-                                isCompleted ? "bg-green-500" : "bg-primary"
+                                "absolute bottom-0 left-0 right-0 transition-all duration-slow ease-out",
+                                isCompleted ? "bg-success" : "bg-primary"
                             )}
                             style={{ height: `${progress}%` }}
                         />
@@ -93,7 +93,7 @@ const JarVisualization = ({ goal, onEdit }) => {
                                 </div>
                                 <div className="flex items-start gap-2 relative z-10">
                                     {isCompleted && (
-                                        <div className="bg-green-100 dark:bg-green-900 text-green-600 dark:text-green-400 p-1.5 rounded-full shadow-sm animate-in zoom-in">
+                                        <div className="bg-success/15 text-success p-1.5 rounded-full shadow-sm animate-in zoom-in">
                                             <Trophy className="h-4 w-4" />
                                         </div>
                                     )}
@@ -121,13 +121,13 @@ const JarVisualization = ({ goal, onEdit }) => {
                             </div>
 
                             <div className="mt-3 space-y-1">
-                                <div className="flex items-baseline gap-1">
+                                <div className="flex items-baseline gap-1 tabular-nums">
                                     <span className="text-2xl font-bold">₹{goal.currentAmount.toLocaleString()}</span>
                                     <span className="text-xs text-muted-foreground">/ ₹{goal.targetAmount.toLocaleString()}</span>
                                 </div>
 
                                 {isCompleted ? (
-                                    <p className="text-sm font-medium text-green-600 flex items-center gap-1">
+                                    <p className="text-sm font-medium text-success flex items-center gap-1">
                                         Goal Reached! 🎉
                                     </p>
                                 ) : (
@@ -146,7 +146,7 @@ const JarVisualization = ({ goal, onEdit }) => {
                                 )}
 
                                 {goal.type === 'investment' && projectedValue && (
-                                    <p className="text-xs text-emerald-600 mt-1 font-medium">
+                                    <p className="text-xs text-success mt-1 font-medium tabular-nums">
                                         Est. Value: ₹{projectedValue.toLocaleString(undefined, { maximumFractionDigits: 0 })}
                                     </p>
                                 )}

--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+// Shared page-title block, replacing the 8 copy-pasted `<h1 className="text-3xl...">` blocks
+// across pages so title/subtitle sizing and spacing stay in one place.
+const PageHeader = ({ title, subtitle, action }) => (
+    <div className="flex justify-between items-end pb-2">
+        <div>
+            <h1 className="text-3xl font-bold tracking-tight text-primary">{title}</h1>
+            {subtitle && <p className="text-muted-foreground mt-1">{subtitle}</p>}
+        </div>
+        {action}
+    </div>
+);
+
+export default PageHeader;

--- a/src/components/RecurringManager.jsx
+++ b/src/components/RecurringManager.jsx
@@ -38,7 +38,7 @@ const RecurringManager = ({ compact }) => {
                             </div>
                         </div>
                         <div className="flex items-center gap-3">
-                            <div className={`font-bold whitespace-nowrap ${plan.type === 'income' ? 'text-green-600' : 'text-red-600'}`}>
+                            <div className={`font-bold whitespace-nowrap tabular-nums ${plan.type === 'income' ? 'text-success' : 'text-destructive'}`}>
                                 {plan.type === 'income' ? '+' : '-'}{formatCurrency(plan.amount).replace('₹', '')}
                             </div>
                             <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -57,7 +57,7 @@ const RecurringManager = ({ compact }) => {
                                 <Button
                                     variant="ghost"
                                     size="icon"
-                                    className="h-7 w-7 text-muted-foreground hover:text-red-600 hover:bg-red-50"
+                                    className="h-7 w-7 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
                                     onClick={() => deleteRecurringPlan(plan.id)}
                                 >
                                     <Trash2 className="h-4 w-4" />

--- a/src/components/SafeToSpendWidget.jsx
+++ b/src/components/SafeToSpendWidget.jsx
@@ -99,7 +99,7 @@ const SafeToSpendWidget = () => {
     };
 
     return (
-        <Card className="bg-card border-border shadow-sm h-full">
+        <Card variant="elevated" className="bg-card border-border h-full">
             <CardHeader className="flex flex-row items-center justify-between pb-2">
                 <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
                     <Calculator className="h-4 w-4" />

--- a/src/components/SafeToSpendWidget.jsx
+++ b/src/components/SafeToSpendWidget.jsx
@@ -107,7 +107,7 @@ const SafeToSpendWidget = () => {
                 </CardTitle>
             </CardHeader>
             <CardContent>
-                <div className="text-4xl font-bold text-primary">
+                <div className="text-4xl font-bold text-primary tabular-nums">
                     {formatCurrency(dailySafeSpend)}
                 </div>
                 <p className="text-xs text-muted-foreground mt-1">
@@ -117,11 +117,11 @@ const SafeToSpendWidget = () => {
                 <div className="mt-4 pt-4 border-t border-border grid grid-cols-2 gap-4 text-xs">
                     <div>
                         <p className="text-muted-foreground">Projected End-Month</p>
-                        <p className="font-semibold text-foreground">{formatCurrency(projectedEndMonth)}</p>
+                        <p className="font-semibold text-foreground tabular-nums">{formatCurrency(projectedEndMonth)}</p>
                     </div>
                     <div>
                         <p className="text-muted-foreground">Upcoming Bills</p>
-                        <p className="font-semibold text-red-500">-{formatCurrency(totalUpcomingExpenses)}</p>
+                        <p className="font-semibold text-destructive tabular-nums">-{formatCurrency(totalUpcomingExpenses)}</p>
                     </div>
                 </div>
             </CardContent>

--- a/src/components/SavingsGoalsWidget.jsx
+++ b/src/components/SavingsGoalsWidget.jsx
@@ -45,7 +45,7 @@ const SavingsGoalsWidget = () => {
                                 </div>
                                 <div className="h-2 w-full bg-secondary rounded-full overflow-hidden">
                                     <div
-                                        className="h-full bg-green-500 transition-all duration-500"
+                                        className="h-full bg-success transition-all duration-slow"
                                         style={{ width: `${progress}%` }}
                                     />
                                 </div>

--- a/src/components/TransactionTable.jsx
+++ b/src/components/TransactionTable.jsx
@@ -124,7 +124,7 @@ const TransactionTable = () => {
                     <CardTitle>Transaction History</CardTitle>
                     <div className="flex gap-2">
                         <select
-                            className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                            className="h-9 rounded-lg border border-input bg-background px-3 text-sm transition-colors duration-fast"
                             value={filterType}
                             onChange={(e) => setFilterType(e.target.value)}
                         >
@@ -194,7 +194,7 @@ const TransactionTable = () => {
                                             <td className="px-4 py-3 text-muted-foreground max-w-[150px] truncate" title={t.description}>
                                                 {t.description || '-'}
                                             </td>
-                                            <td className={`px-4 py-3 text-right font-bold ${t.type === 'income' ? 'text-green-600' : 'text-red-600'}`}>
+                                            <td className={`px-4 py-3 text-right font-bold tabular-nums ${t.type === 'income' ? 'text-success' : 'text-destructive'}`}>
                                                 {t.type === 'income' ? '+' : '-'}{formatCurrency(t.amount)}
                                             </td>
                                             <td className="px-4 py-3 text-right text-muted-foreground font-mono text-xs">
@@ -225,7 +225,7 @@ const TransactionTable = () => {
                                                             <Button
                                                                 variant="ghost"
                                                                 size="icon"
-                                                                className="h-8 w-8 text-muted-foreground hover:text-red-500"
+                                                                className="h-8 w-8 text-muted-foreground hover:text-destructive"
                                                                 onClick={(e) => { e.stopPropagation(); deleteTransaction(t.id); }}
                                                                 title="Delete"
                                                             >
@@ -256,7 +256,7 @@ const TransactionTable = () => {
                                 <h3 className="text-lg font-bold">{viewingTransaction.description || 'No Title'}</h3>
                                 <p className="text-sm text-muted-foreground">{formatDate(viewingTransaction.date)}</p>
                             </div>
-                            <div className={`text-xl font-bold ${viewingTransaction.type === 'income' ? 'text-green-600' : 'text-red-600'}`}>
+                            <div className={`text-xl font-bold tabular-nums ${viewingTransaction.type === 'income' ? 'text-success' : 'text-destructive'}`}>
                                 {viewingTransaction.type === 'income' ? '+' : '-'}{formatCurrency(viewingTransaction.amount)}
                             </div>
                         </div>

--- a/src/components/WishlistWidget.jsx
+++ b/src/components/WishlistWidget.jsx
@@ -101,7 +101,7 @@ const WishlistWidget = () => {
                                         ) : (
                                             <Button
                                                 size="sm"
-                                                className="h-7 px-2 bg-green-600 hover:bg-green-700 text-white"
+                                                className="h-7 px-2 bg-success hover:bg-success/90 text-success-foreground"
                                                 onClick={() => handleBuy(item)}
                                                 title="Buy Now"
                                             >

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -13,15 +13,15 @@ const Button = React.forwardRef(({ className, variant = "default", size = "defau
 
     const sizes = {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-9 px-3",
+        lg: "h-11 px-8",
         icon: "h-10 w-10",
     }
 
     return (
         <button
             className={cn(
-                "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+                "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors duration-fast focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
                 variants[variant],
                 sizes[size],
                 className

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,10 +1,22 @@
 import * as React from "react"
 import { cn } from "../../lib/utils"
 
-const Card = React.forwardRef(({ className, ...props }, ref) => (
+// `variant="elevated"` is for the single hero card per page (e.g. Safe-to-Spend on the
+// Dashboard) - everything else should stay `default` so the elevated card actually reads
+// as more important instead of every card competing for the same visual weight.
+const cardVariants = {
+    default: "shadow-sm",
+    elevated: "shadow-md",
+}
+
+const Card = React.forwardRef(({ className, variant = "default", ...props }, ref) => (
     <div
         ref={ref}
-        className={cn("rounded-lg border border-border bg-card text-card-foreground shadow-sm transition-all duration-200 hover:bg-primary/5", className)}
+        className={cn(
+            "rounded-lg border border-border bg-card text-card-foreground transition-colors duration-normal hover:bg-primary/5",
+            cardVariants[variant],
+            className
+        )}
         {...props}
     />
 ))

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -6,7 +6,7 @@ const Input = React.forwardRef(({ className, type, ...props }, ref) => {
         <input
             type={type}
             className={cn(
-                "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+                "flex h-10 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors duration-fast file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
                 className
             )}
             ref={ref}

--- a/src/components/ui/progress.jsx
+++ b/src/components/ui/progress.jsx
@@ -11,7 +11,7 @@ const Progress = React.forwardRef(({ className, value, ...props }, ref) => (
         {...props}
     >
         <div
-            className="h-full w-full flex-1 bg-primary transition-all"
+            className="h-full w-full flex-1 bg-primary transition-transform duration-slow"
             style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
         />
     </div>
@@ -22,7 +22,7 @@ Progress.displayName = "Progress";
 // (0-100, uncapped) approaches/exceeds 100. Used for budget-vs-actual and similar limit bars.
 const ThresholdProgress = React.forwardRef(({ className, value = 0, ...props }, ref) => {
     const pct = Math.max(0, value);
-    const colorClass = pct >= 100 ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-emerald-500';
+    const colorClass = pct >= 100 ? 'bg-destructive' : pct >= 80 ? 'bg-warning' : 'bg-success';
     return (
         <div
             ref={ref}
@@ -33,7 +33,7 @@ const ThresholdProgress = React.forwardRef(({ className, value = 0, ...props }, 
             {...props}
         >
             <div
-                className={cn("h-full flex-1 transition-all", colorClass)}
+                className={cn("h-full flex-1 transition-[width,background-color] duration-slow", colorClass)}
                 style={{ width: `${Math.min(100, pct)}%` }}
             />
         </div>

--- a/src/components/ui/segmented-control.jsx
+++ b/src/components/ui/segmented-control.jsx
@@ -15,9 +15,9 @@ const SegmentedControl = ({ options, value, onChange, className }) => {
                         type="button"
                         onClick={() => onChange(option.value)}
                         className={cn(
-                            "flex-1 flex items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200",
+                            "flex-1 flex items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md transition-colors duration-normal",
                             isActive
-                                ? "bg-background text-foreground shadow-sm ring-1 ring-black/5"
+                                ? "bg-background text-foreground shadow-sm ring-1 ring-border"
                                 : "text-muted-foreground hover:text-foreground hover:bg-background/50"
                         )}
                     >

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -31,7 +31,7 @@ const Select = React.forwardRef(({ children, value, onValueChange, className, ..
         <div className="relative">
             <select
                 className={cn(
-                    "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 appearance-none",
+                    "flex h-10 w-full items-center justify-between rounded-lg border border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors duration-fast placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 appearance-none",
                     className
                 )}
                 value={value}

--- a/src/components/ui/toast.jsx
+++ b/src/components/ui/toast.jsx
@@ -4,8 +4,8 @@ import { cn } from '../../lib/utils';
 
 const VARIANT_STYLES = {
     default: 'border-border bg-card text-card-foreground',
-    success: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
-    destructive: 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400',
+    success: 'border-success/30 bg-success/10 text-success',
+    destructive: 'border-destructive/30 bg-destructive/10 text-destructive',
 };
 
 const VARIANT_ICONS = {

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,9 @@
     --color-background: var(--background);
     --color-foreground: var(--foreground);
 
+    --color-card: var(--card);
+    --color-card-foreground: var(--card-foreground);
+
     --color-primary: var(--primary);
     --color-primary-foreground: var(--primary-foreground);
 
@@ -51,6 +54,10 @@
     --background: #ffffff;
     --foreground: #09090b;
     /* Zinc 950 */
+
+    /* Card surface - was previously undefined (bg-card/text-card-foreground resolved to nothing) */
+    --card: #ffffff;
+    --card-foreground: #09090b;
 
     /* Primary Blue - Strong, Trustworthy */
     --primary: #2563eb;
@@ -123,6 +130,12 @@
 .dark {
     --background: #09090b;
     /* Zinc 950 */
+
+    /* Card surface - slightly lighter than the page background for subtle elevation */
+    --card: #18181b;
+    /* Zinc 900 */
+    --card-foreground: #fafafa;
+
     --foreground: #fafafa;
     /* Zinc 50 */
 

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,13 @@
     --color-warning: var(--warning);
     --color-warning-foreground: var(--warning-foreground);
 
+    /* Chart Palette - referenced by src/lib/chartTheme.js, adapts per light/dark below */
+    --color-chart-1: var(--chart-1);
+    --color-chart-2: var(--chart-2);
+    --color-chart-3: var(--chart-3);
+    --color-chart-4: var(--chart-4);
+    --color-chart-5: var(--chart-5);
+
     /* Radius */
     --radius-lg: var(--radius);
     --radius-md: calc(var(--radius) - 2px);
@@ -93,6 +100,23 @@
 
     --radius: 0.5rem;
     /* 8px - Cleaner, sharper look */
+
+    /* Chart Palette - categorical, distinct from primary so charts don't blend into UI chrome */
+    --chart-1: #2563eb;
+    /* Blue 600 */
+    --chart-2: #10b981;
+    /* Emerald 500 */
+    --chart-3: #f59e0b;
+    /* Amber 500 */
+    --chart-4: #8b5cf6;
+    /* Violet 500 */
+    --chart-5: #ec4899;
+    /* Pink 500 */
+
+    /* Motion scale - use via transition-[var(--motion-*)] or the .duration-fast/-normal/-slow utilities below */
+    --motion-fast: 150ms;
+    --motion-normal: 300ms;
+    --motion-slow: 500ms;
 }
 
 /* Dark Mode Support (Class-based for manual toggle) */
@@ -121,15 +145,22 @@
     --accent-foreground: #fafafa;
     /* Zinc 50 */
 
-    --destructive: #7f1d1d;
-    /* Red 900 */
-    --destructive-foreground: #fef2f2;
-    /* Red 50 */
+    /* Previously Red/Emerald 900 - nearly invisible against a near-black background.
+       400-level shades stay vivid enough to read as "danger"/"success" in dark mode. */
+    --destructive: #f87171;
+    /* Red 400 */
+    --destructive-foreground: #450a0a;
+    /* Red 950, for text placed directly on the destructive color */
 
-    --success: #064e3b;
-    /* Emerald 900 */
-    --success-foreground: #ecfdf5;
-    /* Emerald 50 */
+    --success: #34d399;
+    /* Emerald 400 */
+    --success-foreground: #022c22;
+    /* Emerald 950 */
+
+    --warning: #fbbf24;
+    /* Amber 400 */
+    --warning-foreground: #451a03;
+    /* Amber 950 */
 
     --border: #27272a;
     /* Zinc 800 */
@@ -137,6 +168,18 @@
     /* Zinc 800 */
     --ring: #3b82f6;
     /* Blue 500 */
+
+    /* Chart Palette - lighter shades for visibility against the dark background */
+    --chart-1: #60a5fa;
+    /* Blue 400 */
+    --chart-2: #34d399;
+    /* Emerald 400 */
+    --chart-3: #fbbf24;
+    /* Amber 400 */
+    --chart-4: #a78bfa;
+    /* Violet 400 */
+    --chart-5: #f472b6;
+    /* Pink 400 */
 }
 
 /* Global Resets & Typography */
@@ -149,4 +192,17 @@ body {
 /* Utility for consistent "Box" styling */
 .card-base {
     @apply bg-background border-none shadow-lg rounded-2xl;
+}
+
+/* Motion scale - pair with a transition-* utility, e.g. `transition-colors duration-fast` */
+.duration-fast {
+    transition-duration: var(--motion-fast);
+}
+
+.duration-normal {
+    transition-duration: var(--motion-normal);
+}
+
+.duration-slow {
+    transition-duration: var(--motion-slow);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,9 @@
     --color-card: var(--card);
     --color-card-foreground: var(--card-foreground);
 
+    --color-popover: var(--popover);
+    --color-popover-foreground: var(--popover-foreground);
+
     --color-primary: var(--primary);
     --color-primary-foreground: var(--primary-foreground);
 
@@ -58,6 +61,10 @@
     /* Card surface - was previously undefined (bg-card/text-card-foreground resolved to nothing) */
     --card: #ffffff;
     --card-foreground: #09090b;
+
+    /* Popover/tooltip surface - was also previously undefined */
+    --popover: #ffffff;
+    --popover-foreground: #09090b;
 
     /* Primary Blue - Strong, Trustworthy */
     --primary: #2563eb;
@@ -135,6 +142,10 @@
     --card: #18181b;
     /* Zinc 900 */
     --card-foreground: #fafafa;
+
+    --popover: #18181b;
+    /* Zinc 900 */
+    --popover-foreground: #fafafa;
 
     --foreground: #fafafa;
     /* Zinc 50 */

--- a/src/lib/chartTheme.js
+++ b/src/lib/chartTheme.js
@@ -1,0 +1,20 @@
+// Shared Recharts styling, sourced from the CSS custom properties in src/index.css so charts
+// stay on-brand and adapt automatically to light/dark mode instead of using literal hex values.
+export const CHART_COLORS = [
+    'var(--chart-1)',
+    'var(--chart-2)',
+    'var(--chart-3)',
+    'var(--chart-4)',
+    'var(--chart-5)',
+];
+
+// Shared Tooltip content styling (Recharts renders this as inline styles on a wrapper div,
+// so it can reference the same CSS vars as the rest of the app).
+export const chartTooltipStyle = {
+    backgroundColor: 'var(--popover)',
+    color: 'var(--popover-foreground)',
+    border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-lg)',
+    fontSize: '12px',
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+};

--- a/src/pages/BudgetsPage.jsx
+++ b/src/pages/BudgetsPage.jsx
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { ThresholdProgress } from '../components/ui/progress';
 import { Trash2, Plus, Wallet2 } from 'lucide-react';
 import EmptyState from '../components/EmptyState';
+import { cn } from '../lib/utils';
 
 const BudgetsPage = () => {
     const { budgets, addBudget, updateBudget, deleteBudget, transactions, categories, isPrivacyMode } = useFinancial();
@@ -138,7 +139,7 @@ const BudgetsPage = () => {
                                             <Button
                                                 variant="ghost"
                                                 size="icon"
-                                                className="h-7 w-7 text-muted-foreground hover:text-red-500"
+                                                className="h-7 w-7 text-muted-foreground hover:text-destructive"
                                                 onClick={() => deleteBudget(budget.id)}
                                                 title="Delete budget"
                                             >
@@ -150,7 +151,7 @@ const BudgetsPage = () => {
                                     <ThresholdProgress value={pct} />
 
                                     <div className="flex items-center justify-between text-xs">
-                                        <span className={pct >= 100 ? 'text-red-500 font-medium' : 'text-muted-foreground'}>
+                                        <span className={cn('tabular-nums', pct >= 100 ? 'text-destructive font-medium' : 'text-muted-foreground')}>
                                             {formatCurrency(spent)} spent this month
                                         </span>
                                         <span className="text-muted-foreground">{Math.round(pct)}%</span>

--- a/src/pages/BudgetsPage.jsx
+++ b/src/pages/BudgetsPage.jsx
@@ -8,6 +8,7 @@ import { ThresholdProgress } from '../components/ui/progress';
 import { Trash2, Plus, Wallet2 } from 'lucide-react';
 import EmptyState from '../components/EmptyState';
 import { cn } from '../lib/utils';
+import PageHeader from '../components/PageHeader';
 
 const BudgetsPage = () => {
     const { budgets, addBudget, updateBudget, deleteBudget, transactions, categories, isPrivacyMode } = useFinancial();
@@ -57,10 +58,7 @@ const BudgetsPage = () => {
 
     return (
         <div className="space-y-6">
-            <div className="pb-2">
-                <h1 className="text-3xl font-bold tracking-tight text-primary">Budgets</h1>
-                <p className="text-muted-foreground mt-1">Set a monthly limit per category and track actual spend against it.</p>
-            </div>
+            <PageHeader title="Budgets" subtitle="Set a monthly limit per category and track actual spend against it." />
 
             <Card>
                 <CardHeader>

--- a/src/pages/CoachPage.jsx
+++ b/src/pages/CoachPage.jsx
@@ -9,6 +9,7 @@ import { MessageSquare, Send, Sparkles, TrendingUp, GraduationCap, ShoppingBag, 
 import { cn } from '../lib/utils';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import PageHeader from '../components/PageHeader';
 
 const MODES = [
     {
@@ -94,14 +95,7 @@ const CoachPage = () => {
 
     return (
         <div className="h-full flex flex-col gap-6">
-            <div className="pb-2">
-                <h1 className="text-3xl font-bold tracking-tight text-primary">
-                    Financial Coach
-                </h1>
-                <p className="text-muted-foreground mt-1">
-                    Your personal AI expert for every financial decision.
-                </p>
-            </div>
+            <PageHeader title="Financial Coach" subtitle="Your personal AI expert for every financial decision." />
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 {MODES.map(mode => (

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -22,7 +22,7 @@ const DashboardPage = () => {
             <PageHeader title={`Hi, ${firstName}`} subtitle="Here's your financial overview for today." />
 
             {/* Bento Grid - Viewport Fit */}
-            <div className="grid grid-cols-1 md:grid-cols-4 grid-rows-[auto_auto_auto_1fr] gap-3 h-[calc(100vh-10rem)] min-h-[600px]">
+            <div className="grid grid-cols-1 md:grid-cols-4 grid-rows-[auto_auto_auto_1fr] gap-4 h-[calc(100vh-10rem)] min-h-[600px]">
                 {/* Row 1: AI Quick Add (Span 4, Fixed Height) */}
                 <div className="md:col-span-4 h-fit">
                     <NaturalLanguageInput onManualEntry={() => setIsTransactionModalOpen(true)} />
@@ -40,7 +40,7 @@ const DashboardPage = () => {
                 </div>
 
                 {/* Row 3: Financial Summary (2), Budget Summary (2) & Simulator (3) */}
-                <div className="md:col-span-4 grid grid-cols-1 md:grid-cols-7 gap-3">
+                <div className="md:col-span-4 grid grid-cols-1 md:grid-cols-7 gap-4">
                     <div className="md:col-span-2">
                         <FinancialSummaryCard />
                     </div>

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -8,6 +8,7 @@ import SpendingMonitor from '../components/SpendingMonitor';
 import Dialog from '../components/ui/dialog';
 import AddTransactionForm from '../components/AddTransactionForm';
 import SafeToSpendWidget from '../components/SafeToSpendWidget';
+import PageHeader from '../components/PageHeader';
 
 const DashboardPage = () => {
     const { user } = useAuth();
@@ -18,11 +19,7 @@ const DashboardPage = () => {
 
     return (
         <div className="space-y-4">
-            {/* Greeting Header */}
-            <div className="pb-2">
-                <h1 className="text-3xl font-bold tracking-tight text-primary">Hi, {firstName}! 👋</h1>
-                <p className="text-muted-foreground mt-1">Here's your financial overview for today.</p>
-            </div>
+            <PageHeader title={`Hi, ${firstName}`} subtitle="Here's your financial overview for today." />
 
             {/* Bento Grid - Viewport Fit */}
             <div className="grid grid-cols-1 md:grid-cols-4 grid-rows-[auto_auto_auto_1fr] gap-3 h-[calc(100vh-10rem)] min-h-[600px]">

--- a/src/pages/GoalsPage.jsx
+++ b/src/pages/GoalsPage.jsx
@@ -6,6 +6,7 @@ import Dialog from '../components/ui/dialog';
 import JarVisualization from '../components/JarVisualization';
 import JarCreationForm from '../components/JarCreationForm';
 import ImpulseControl from '../components/ImpulseControl';
+import PageHeader from '../components/PageHeader';
 
 const GoalsPage = () => {
     const { savingsGoals } = useFinancial();
@@ -24,16 +25,16 @@ const GoalsPage = () => {
 
     return (
         <div className="space-y-6">
-            <div className="flex justify-between items-end pb-2">
-                <div>
-                    <h1 className="text-3xl font-bold tracking-tight text-primary">Goals & Jars</h1>
-                    <p className="text-muted-foreground mt-1">Your path to guilt-free spending.</p>
-                </div>
-                <Button onClick={handleCreate} className="bg-primary hover:bg-primary/90 shadow-sm">
-                    <Plus className="mr-2 h-4 w-4" />
-                    New Jar
-                </Button>
-            </div>
+            <PageHeader
+                title="Goals & Jars"
+                subtitle="Your path to guilt-free spending."
+                action={
+                    <Button onClick={handleCreate} className="bg-primary hover:bg-primary/90 shadow-sm">
+                        <Plus className="mr-2 h-4 w-4" />
+                        New Jar
+                    </Button>
+                }
+            />
 
             <div className="grid gap-6 md:grid-cols-12 h-[calc(100vh-12rem)]">
                 {/* Savings Jars Section */}

--- a/src/pages/InsightsPage.jsx
+++ b/src/pages/InsightsPage.jsx
@@ -1,13 +1,11 @@
 import { SpendingComparisonWidget, TrendPredictionWidget } from '../components/InsightsWidgets';
 import InsightsDashboard from '../components/InsightsDashboard';
+import PageHeader from '../components/PageHeader';
 
 const InsightsPage = () => {
     return (
         <div className="space-y-6">
-            <div className="pb-2">
-                <h1 className="text-3xl font-bold tracking-tight text-primary">Insights</h1>
-                <p className="text-muted-foreground mt-1">Analyze your spending patterns and trends.</p>
-            </div>
+            <PageHeader title="Insights" subtitle="Analyze your spending patterns and trends." />
 
             <div className="grid gap-4 md:grid-cols-2">
                 <TrendPredictionWidget />

--- a/src/pages/LedgerPage.jsx
+++ b/src/pages/LedgerPage.jsx
@@ -4,22 +4,23 @@ import { Button } from '../components/ui/button';
 import { Settings } from 'lucide-react';
 import Dialog from '../components/ui/dialog';
 import CategoryManager from '../components/CategoryManager';
+import PageHeader from '../components/PageHeader';
 
 const LedgerPage = () => {
     const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
 
     return (
         <div className="space-y-6">
-            <div className="flex justify-between items-end pb-2">
-                <div>
-                    <h1 className="text-3xl font-bold tracking-tight text-primary">Ledger</h1>
-                    <p className="text-muted-foreground mt-1">Complete history of all your transactions.</p>
-                </div>
-                <Button variant="outline" onClick={() => setIsCategoryModalOpen(true)}>
-                    <Settings className="mr-2 h-4 w-4" />
-                    Manage Categories
-                </Button>
-            </div>
+            <PageHeader
+                title="Ledger"
+                subtitle="Complete history of all your transactions."
+                action={
+                    <Button variant="outline" onClick={() => setIsCategoryModalOpen(true)}>
+                        <Settings className="mr-2 h-4 w-4" />
+                        Manage Categories
+                    </Button>
+                }
+            />
 
             <TransactionTable />
 

--- a/src/pages/PlannerPage.jsx
+++ b/src/pages/PlannerPage.jsx
@@ -3,14 +3,12 @@ import CommitmentsHub from '../components/CommitmentsHub';
 import FiscalCalendar from '../components/FiscalCalendar';
 import CashFlowForecast from '../components/CashFlowForecast';
 import FutureTransactions from '../components/FutureTransactions';
+import PageHeader from '../components/PageHeader';
 
 const PlannerPage = () => {
     return (
         <div className="space-y-6">
-            <div className="pb-2">
-                <h1 className="text-3xl font-bold tracking-tight text-primary">Planner</h1>
-                <p className="text-muted-foreground mt-1">Manage your recurring commitments and future expenses.</p>
-            </div>
+            <PageHeader title="Planner" subtitle="Manage your recurring commitments and future expenses." />
 
             <div className="h-[calc(100vh-8rem)] grid gap-6 md:grid-cols-12">
                 {/* Main Timeline Area */}

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -11,6 +11,7 @@ import { Select } from '../components/ui/select';
 import { User, Shield, Calendar, LogOut, Edit2, Download, Wallet, Target, Brain, AlertTriangle, Moon, Sun, Laptop, Lock, Trash2 } from 'lucide-react';
 import { api } from '../lib/api';
 import Achievements from '../components/Achievements';
+import PageHeader from '../components/PageHeader';
 
 const ProfilePage = () => {
     const { isPrivacyMode, togglePrivacyMode } = useFinancial();
@@ -119,16 +120,16 @@ const ProfilePage = () => {
 
     return (
         <div className="space-y-6 pb-20">
-            <div className="flex items-center justify-between pb-2">
-                <div>
-                    <h1 className="text-3xl font-bold tracking-tight text-primary">Profile & Settings</h1>
-                    <p className="text-muted-foreground mt-1">Manage your account, AI persona, and preferences.</p>
-                </div>
-                <Button variant="destructive" size="sm" onClick={logout} className="gap-2">
-                    <LogOut className="h-4 w-4" />
-                    Sign Out
-                </Button>
-            </div>
+            <PageHeader
+                title="Profile & Settings"
+                subtitle="Manage your account, AI persona, and preferences."
+                action={
+                    <Button variant="destructive" size="sm" onClick={logout} className="gap-2">
+                        <LogOut className="h-4 w-4" />
+                        Sign Out
+                    </Button>
+                }
+            />
 
             <div className="grid gap-6 md:grid-cols-2">
                 {/* Identity Card */}


### PR DESCRIPTION
## Summary
Professionalizes the UI per a full design-token audit, without adding any new features or restructuring layouts. Fixes two real bugs found along the way: `--card` and `--popover` CSS variables were referenced everywhere (`bg-card`, `bg-popover`, etc.) but never defined, so those surfaces were silently falling back to nothing.

- **Tokens**: dark-mode `--success`/`--destructive`/`--warning` were 900-level shades nearly invisible against the near-black background - bumped to 400-level; added a themeable 5-color `--chart-1..5` palette (distinct light/dark values); added `--motion-fast/normal/slow` (150/300/500ms) to replace arbitrary durations; defined the missing `--card`/`--popover` tokens.
- **Primitives**: unified Button/Input/Select to `rounded-lg` (was 6px vs. Card's 8px); added a Card `variant` prop (`default`/`elevated`); `ThresholdProgress` now uses `success`/`warning`/`destructive` tokens instead of hardcoded Tailwind colors.
- **Color sweep**: replaced hardcoded `text-green-*`/`text-red-*`/`bg-emerald-*` money-state colors with semantic tokens across ~19 components (DebtTracker, TransactionTable, CashFlowForecast, JarVisualization, FiscalCalendar, ImpulseControl, etc.), and added `tabular-nums` to money amount displays so figures align in columns.
- **Charts**: new `src/lib/chartTheme.js` sourcing colors from CSS vars - `ExpenseBreakdown`'s pie chart is now dark-mode aware instead of hardcoded hex.
- **Typography/consistency**: new shared `PageHeader` component replacing 8 copy-pasted header blocks; removed the emoji from Dashboard's greeting per design decision (kept only for genuine goal-celebration moments in `JarVisualization`).
- **Dashboard polish**: `SafeToSpendWidget` is now the one `elevated` hero card, `FinancialSummaryCard`'s one-off `rounded-2xl`/`shadow-lg` override removed to match the rest, grid spacing normalized to `gap-4`.
- Version bumped to 1.3.0.

## Test plan
- [x] `npm run build` clean and backend imports cleanly after every commit (verified locally)
- [x] Manual visual pass in both light and dark mode - especially: destructive/success color visibility in dark mode, pie chart colors, aligned amount columns in the Ledger, consistent card radii/shadows on the Dashboard
- [x] Confirm the `--card`/`--popover` fix didn't change any card's visible background unexpectedly (was previously falling back silently)