### PR TITLE
Phase 6: Document import (CSV/PDF statement upload → review → merge)

### DIFF
--- a/backend/ai_service.py
+++ b/backend/ai_service.py
@@ -183,6 +183,52 @@ async def classify_transaction(text: str):
         print(f"Raw response: {response.text}")
         raise Exception("Failed to classify transaction")
 
+STATEMENT_PARSE_PROMPT = """
+You are a bank statement parser. Below is raw text extracted from a PDF bank/card statement.
+Extract every individual transaction line into a JSON array. Ignore headers, footers, balance
+summaries, and page numbers - only actual transaction rows.
+
+Each entry: { "date": "YYYY-MM-DD", "amount": float (always positive), "type": "expense"|"income",
+"description": str }
+
+Rules:
+- "type": "income" for credits/deposits, "expense" for debits/withdrawals/payments.
+- "amount": always positive; the "type" field carries the direction.
+- "description": the merchant/narration text as printed, trimmed.
+- If a date has no year, infer the most recent plausible year from context (statement period, if visible).
+- Skip lines that aren't real transactions (opening/closing balance, page headers, disclaimers).
+
+Return ONLY the JSON array, nothing else.
+
+Statement text:
+{statement_text}
+"""
+
+
+async def parse_statement_text(text: str):
+    """One AI call for the whole document (not per line) - PDFs don't have the reliable
+    column structure a CSV does, so this is where AI-assisted extraction earns its cost,
+    unlike per-row categorization which would be needlessly slow (see CSV path)."""
+    # Cap input size - a huge statement would blow the model's context and cost; a few
+    # thousand characters covers a multi-page statement's worth of transaction lines.
+    truncated = text[:15000]
+    prompt = STATEMENT_PARSE_PROMPT.replace("{statement_text}", truncated)
+
+    if OLLAMA_ENABLED:
+        try:
+            raw = _call_ollama(prompt, timeout=60)
+            return _parse_action_array(raw)
+        except Exception as e:
+            print(f"Local model statement parsing failed, falling back to Gemini: {e}")
+
+    if not API_KEY:
+        raise Exception("API Key missing")
+
+    model = genai.GenerativeModel(GEMINI_FALLBACK_MODEL)
+    response = model.generate_content(prompt)
+    return _parse_action_array(response.text)
+
+
 async def analyze_purchase(query: str, context: dict):
     if not API_KEY:
         raise Exception("API Key missing")

--- a/backend/ai_service.py
+++ b/backend/ai_service.py
@@ -27,14 +27,19 @@ OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "phi4-mini")
 
 
-def _call_ollama(prompt: str, timeout: int = 20) -> str:
+def _call_ollama(prompt: str, timeout: int = 20, num_predict: int = None) -> str:
     """Send a single-turn prompt to the local Ollama model. Raises on any failure
-    (connection refused, timeout, non-2xx) so callers can fall back to Gemini."""
-    response = requests.post(
-        f"{OLLAMA_HOST}/api/generate",
-        json={"model": OLLAMA_MODEL, "prompt": prompt, "stream": False},
-        timeout=timeout,
-    )
+    (connection refused, timeout, non-2xx) so callers can fall back to Gemini.
+
+    `num_predict` caps generation length - Ollama's per-model default (often a few
+    hundred tokens) is fine for short structured replies but silently truncates a
+    long JSON array mid-object for something like a full statement's worth of
+    transactions, which then fails to parse. Callers with large expected outputs
+    should pass an explicit budget."""
+    payload = {"model": OLLAMA_MODEL, "prompt": prompt, "stream": False}
+    if num_predict is not None:
+        payload["options"] = {"num_predict": num_predict}
+    response = requests.post(f"{OLLAMA_HOST}/api/generate", json=payload, timeout=timeout)
     response.raise_for_status()
     return response.json().get("response", "")
 
@@ -205,28 +210,48 @@ Statement text:
 """
 
 
+def _friendly_gemini_error(e: Exception) -> str:
+    """Gemini/google-api-core exceptions are verbose and nest a raw gRPC error
+    message - this maps the common cases to something a user can actually act on."""
+    msg = str(e)
+    if "API_KEY_INVALID" in msg or "API key not valid" in msg:
+        return "Gemini API key is invalid or has been revoked. Get a new key at aistudio.google.com/apikey and update GEMINI_API_KEY/VITE_GEMINI_API_KEY in your .env, or run Ollama locally so cloud AI isn't needed."
+    if "RESOURCE_EXHAUSTED" in msg or "429" in msg[:10]:
+        return "Gemini's free-tier quota is exhausted for now. Try again later, or run Ollama locally so cloud AI isn't needed."
+    return f"Gemini request failed: {msg}"
+
+
 async def parse_statement_text(text: str):
     """One AI call for the whole document (not per line) - PDFs don't have the reliable
     column structure a CSV does, so this is where AI-assisted extraction earns its cost,
     unlike per-row categorization which would be needlessly slow (see CSV path)."""
-    # Cap input size - a huge statement would blow the model's context and cost; a few
-    # thousand characters covers a multi-page statement's worth of transaction lines.
-    truncated = text[:15000]
-    prompt = STATEMENT_PARSE_PROMPT.replace("{statement_text}", truncated)
-
+    ollama_error = None
     if OLLAMA_ENABLED:
         try:
-            raw = _call_ollama(prompt, timeout=60)
+            # phi4-mini's context is much smaller than Gemini's - truncate tighter here
+            # than the Gemini path below, and give generation a large enough token
+            # budget that a full statement's worth of transactions isn't cut off
+            # mid-array (Ollama's per-model default budget is easily too small for this).
+            truncated = text[:6000]
+            prompt = STATEMENT_PARSE_PROMPT.replace("{statement_text}", truncated)
+            raw = _call_ollama(prompt, timeout=90, num_predict=4096)
             return _parse_action_array(raw)
         except Exception as e:
+            ollama_error = e
             print(f"Local model statement parsing failed, falling back to Gemini: {e}")
 
     if not API_KEY:
-        raise Exception("API Key missing")
+        detail = "No AI backend available: Ollama is unreachable/disabled" + (f" ({ollama_error})" if ollama_error else "") + " and no Gemini API key is configured."
+        raise Exception(detail)
 
-    model = genai.GenerativeModel(GEMINI_FALLBACK_MODEL)
-    response = model.generate_content(prompt)
-    return _parse_action_array(response.text)
+    try:
+        truncated = text[:15000]
+        prompt = STATEMENT_PARSE_PROMPT.replace("{statement_text}", truncated)
+        model = genai.GenerativeModel(GEMINI_FALLBACK_MODEL)
+        response = model.generate_content(prompt)
+        return _parse_action_array(response.text)
+    except Exception as e:
+        raise Exception(_friendly_gemini_error(e))
 
 
 async def analyze_purchase(query: str, context: dict):

--- a/backend/ai_service.py
+++ b/backend/ai_service.py
@@ -4,6 +4,7 @@ import json
 import re
 import requests
 from dotenv import load_dotenv
+import statement_parser
 
 load_dotenv()
 
@@ -189,9 +190,11 @@ async def classify_transaction(text: str):
         raise Exception("Failed to classify transaction")
 
 STATEMENT_PARSE_PROMPT = """
-You are a bank statement parser. Below is raw text extracted from a PDF bank/card statement.
-Extract every individual transaction line into a JSON array. Ignore headers, footers, balance
-summaries, and page numbers - only actual transaction rows.
+You are a bank statement parser. Below is raw text extracted from ONE PAGE (or a chunk of one)
+of a PDF bank/card statement. Extract every individual transaction line into a JSON array.
+Ignore headers, footers, balance summaries, and page numbers - only actual transaction rows.
+This chunk may start or end mid-page; only extract complete, clearly-identifiable transaction
+rows - if a line looks cut off or ambiguous, skip it rather than guessing.
 
 Each entry: { "date": "YYYY-MM-DD", "amount": float (always positive), "type": "expense"|"income",
 "description": str }
@@ -199,11 +202,14 @@ Each entry: { "date": "YYYY-MM-DD", "amount": float (always positive), "type": "
 Rules:
 - "type": "income" for credits/deposits, "expense" for debits/withdrawals/payments.
 - "amount": always positive; the "type" field carries the direction.
-- "description": the merchant/narration text as printed, trimmed.
+- "description": the merchant/narration text as printed, trimmed. Some digit sequences may
+  already appear masked as XXXXXXXX1234 or [REDACTED-...] - leave those exactly as-is, do not
+  attempt to reconstruct or guess the original numbers.
 - If a date has no year, infer the most recent plausible year from context (statement period, if visible).
 - Skip lines that aren't real transactions (opening/closing balance, page headers, disclaimers).
+- Never include full account numbers, card numbers, or customer IDs in your output even if present.
 
-Return ONLY the JSON array, nothing else.
+Return ONLY the JSON array, nothing else. If this chunk has no transactions, return [].
 
 Statement text:
 {statement_text}
@@ -221,21 +227,57 @@ def _friendly_gemini_error(e: Exception) -> str:
     return f"Gemini request failed: {msg}"
 
 
+# Hard cap on how many chunks a single statement gets split into. A 9-page, 3-month
+# statement can run to several hundred transaction lines - this bounds worst-case
+# latency (and, for Gemini, request count) instead of looping indefinitely on a huge
+# upload. Whatever fits in the first MAX_CHUNKS chunks gets parsed; anything past that
+# is dropped with a server-side log line rather than silently truncating input text.
+MAX_CHUNKS = 40
+
+
+def _statement_chunks(text: str, max_chars: int) -> list:
+    chunks = statement_parser.chunk_text_by_lines(text, max_chars)
+    if len(chunks) > MAX_CHUNKS:
+        print(f"Statement produced {len(chunks)} chunks, capping at {MAX_CHUNKS} (some transactions may be missed)")
+        chunks = chunks[:MAX_CHUNKS]
+    return chunks
+
+
 async def parse_statement_text(text: str):
-    """One AI call for the whole document (not per line) - PDFs don't have the reliable
-    column structure a CSV does, so this is where AI-assisted extraction earns its cost,
-    unlike per-row categorization which would be needlessly slow (see CSV path)."""
+    """Whole-document parse, chunked across multiple AI calls rather than one call on
+    a truncated prefix - a multi-page statement's later pages were previously dropped
+    entirely. Redacts PII from the text once, up front, before any chunk reaches an
+    AI model (local or cloud)."""
+    text = statement_parser.redact_pii(text)
+
     ollama_error = None
     if OLLAMA_ENABLED:
         try:
-            # phi4-mini's context is much smaller than Gemini's - truncate tighter here
-            # than the Gemini path below, and give generation a large enough token
-            # budget that a full statement's worth of transactions isn't cut off
-            # mid-array (Ollama's per-model default budget is easily too small for this).
-            truncated = text[:6000]
-            prompt = STATEMENT_PARSE_PROMPT.replace("{statement_text}", truncated)
-            raw = _call_ollama(prompt, timeout=90, num_predict=4096)
-            return _parse_action_array(raw)
+            # phi4-mini's completeness drops sharply on long, repetitive extraction -
+            # tested empirically at ~93% recall on a ~28-line/1500-char chunk vs. ~47%
+            # on a ~60-line/4000-char chunk. Small chunks trade more (slower) calls for
+            # far fewer silently-dropped transactions, which matters more for a bulk
+            # import. Generation budget stays generous so one chunk's output isn't cut
+            # off mid-array (Ollama's per-model default budget is easily too small).
+            chunks = _statement_chunks(text, max_chars=1500)
+            results = []
+            failed_chunks = 0
+            for i, chunk in enumerate(chunks):
+                prompt = STATEMENT_PARSE_PROMPT.replace("{statement_text}", chunk)
+                try:
+                    raw = _call_ollama(prompt, timeout=90, num_predict=4096)
+                    results.extend(_parse_action_array(raw))
+                except Exception as chunk_error:
+                    failed_chunks += 1
+                    if i == 0 and failed_chunks == 1:
+                        # First chunk failing usually means Ollama itself is down/
+                        # unreachable, not a one-off parse hiccup - stop wasting time
+                        # retrying and fall back to Gemini for the whole document.
+                        raise
+                    print(f"Skipping statement chunk {i + 1}/{len(chunks)} after parse failure: {chunk_error}")
+            if failed_chunks:
+                print(f"Statement parsed via Ollama with {failed_chunks}/{len(chunks)} chunk(s) skipped")
+            return results
         except Exception as e:
             ollama_error = e
             print(f"Local model statement parsing failed, falling back to Gemini: {e}")
@@ -244,14 +286,22 @@ async def parse_statement_text(text: str):
         detail = "No AI backend available: Ollama is unreachable/disabled" + (f" ({ollama_error})" if ollama_error else "") + " and no Gemini API key is configured."
         raise Exception(detail)
 
-    try:
-        truncated = text[:15000]
-        prompt = STATEMENT_PARSE_PROMPT.replace("{statement_text}", truncated)
-        model = genai.GenerativeModel(GEMINI_FALLBACK_MODEL)
-        response = model.generate_content(prompt)
-        return _parse_action_array(response.text)
-    except Exception as e:
-        raise Exception(_friendly_gemini_error(e))
+    chunks = _statement_chunks(text, max_chars=12000)
+    results = []
+    model = genai.GenerativeModel(GEMINI_FALLBACK_MODEL)
+    for i, chunk in enumerate(chunks):
+        prompt = STATEMENT_PARSE_PROMPT.replace("{statement_text}", chunk)
+        try:
+            response = model.generate_content(prompt)
+            results.extend(_parse_action_array(response.text))
+        except Exception as chunk_error:
+            if i == 0:
+                # First chunk failing means Gemini itself is unusable (bad key, quota,
+                # network) - not worth burning through every remaining chunk to find
+                # that out. Surface one clear, actionable error instead.
+                raise Exception(_friendly_gemini_error(chunk_error))
+            print(f"Skipping statement chunk {i + 1}/{len(chunks)} after Gemini failure: {chunk_error}")
+    return results
 
 
 async def analyze_purchase(query: str, context: dict):

--- a/backend/alembic/versions/4e676b652606_add_source_column_to_transactions.py
+++ b/backend/alembic/versions/4e676b652606_add_source_column_to_transactions.py
@@ -1,0 +1,30 @@
+"""add source column to transactions
+
+Revision ID: 4e676b652606
+Revises: 3d52f3495e78
+Create Date: 2026-07-03 17:54:14.695102
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4e676b652606'
+down_revision: Union[str, Sequence[str], None] = '3d52f3495e78'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('transactions') as batch_op:
+        batch_op.add_column(sa.Column('source', sa.String(), nullable=True, server_default='manual'))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('transactions') as batch_op:
+        batch_op.drop_column('source')

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,11 +8,11 @@ import models, schemas, auth_utils
 from database import SessionLocal, engine, get_db
 import uuid
 from datetime import timedelta
-from routers import auth, goals, transactions, recurring, debts, ai, budgets
+from routers import auth, goals, transactions, recurring, debts, ai, budgets, import_router
 
 models.Base.metadata.create_all(bind=engine)
 
-app = FastAPI(title="BuFin API", version="2.0.0")
+app = FastAPI(title="BuFin API", version="2.1.0")
 
 # CORS Middleware
 app.add_middleware(
@@ -30,6 +30,7 @@ app.include_router(recurring.router, prefix="/api", tags=["recurring"])
 app.include_router(debts.router, prefix="/api", tags=["debts"])
 app.include_router(ai.router, prefix="/api", tags=["ai"])
 app.include_router(budgets.router, prefix="/api", tags=["budgets"])
+app.include_router(import_router.router, prefix="/api", tags=["import"])
 
 from google.api_core.exceptions import ResourceExhausted
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -16,6 +16,7 @@ class Transaction(Base):
     necessity = Column(String) # 'fixed' or 'variable'
     remarks = Column(String, nullable=True)
     linked_debt_id = Column(String, ForeignKey("debts.id"), nullable=True) # set for auto-created debt repayment transactions
+    source = Column(String, default="manual") # 'manual' | 'imported' - provenance badge in the Ledger
 
 class RecurringPlan(Base):
     __tablename__ = "recurring_plans"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,5 @@ passlib==1.7.4
 bcrypt==4.0.1
 email-validator==2.3.0
 requests==2.32.5
+pypdf==5.1.0
+python-multipart==0.0.20

--- a/backend/routers/import_router.py
+++ b/backend/routers/import_router.py
@@ -57,14 +57,20 @@ async def parse_statement(
                 # currently usable" (bad/missing Gemini key, Ollama down), a service-side
                 # config problem the user needs to fix, not a bad upload.
                 raise HTTPException(status_code=503, detail=str(e))
-            candidates = [{
-                "date": r.get("date"),
-                "amount": abs(float(r.get("amount", 0))),
-                "type": r.get("type", "expense"),
-                "merchant": (r.get("description") or "")[:60] or None,
-                "description": r.get("description"),
-                "category": statement_parser.guess_category(r.get("description", "")),
-            } for r in raw_candidates if r.get("date") and r.get("amount")]
+            candidates = []
+            for r in raw_candidates:
+                if not r.get("date") or not r.get("amount"):
+                    continue
+                raw_description = r.get("description") or ""
+                merchant, is_peer_transfer = statement_parser.clean_merchant_name(raw_description)
+                candidates.append({
+                    "date": r.get("date"),
+                    "amount": abs(float(r.get("amount", 0))),
+                    "type": r.get("type", "expense"),
+                    "merchant": merchant or None,
+                    "description": raw_description or None,
+                    "category": statement_parser.guess_category(merchant, is_peer_transfer),
+                })
             skipped = len(raw_candidates) - len(candidates)
             source_type = "pdf"
         else:

--- a/backend/routers/import_router.py
+++ b/backend/routers/import_router.py
@@ -1,0 +1,100 @@
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from sqlalchemy.orm import Session
+import models, schemas
+from database import get_db
+from .auth import get_current_user
+import statement_parser
+import ai_service
+import uuid
+
+router = APIRouter()
+
+MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB - statements are text, not media
+
+
+def _mark_duplicates(candidates: list, existing_transactions: list):
+    """Same-date, same-amount (within a cent) match against the user's existing ledger.
+    Defaults matched rows to skipped in the review UI rather than silently merging them."""
+    existing_index = {}
+    for t in existing_transactions:
+        key = (t.date[:10], round(t.amount, 2), t.type)
+        existing_index.setdefault(key, 0)
+        existing_index[key] += 1
+
+    for c in candidates:
+        key = (c["date"], round(c["amount"], 2), c["type"])
+        if existing_index.get(key, 0) > 0:
+            c["is_duplicate"] = True
+            c["duplicate_reason"] = "Matches an existing transaction on the same date and amount"
+        else:
+            c["is_duplicate"] = False
+
+
+@router.post("/import/parse", response_model=schemas.ImportParseResponse)
+async def parse_statement(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    content = await file.read()
+    if len(content) > MAX_FILE_SIZE:
+        raise HTTPException(status_code=400, detail="File too large - statements are limited to 5MB")
+
+    filename = file.filename or "statement"
+    is_pdf = filename.lower().endswith(".pdf") or file.content_type == "application/pdf"
+
+    try:
+        if is_pdf:
+            text = statement_parser.extract_pdf_text(content)
+            if not text.strip():
+                raise HTTPException(status_code=400, detail="Couldn't extract any text from this PDF - it may be a scanned image rather than a text-based statement")
+            raw_candidates = await ai_service.parse_statement_text(text)
+            candidates = [{
+                "date": r.get("date"),
+                "amount": abs(float(r.get("amount", 0))),
+                "type": r.get("type", "expense"),
+                "merchant": (r.get("description") or "")[:60] or None,
+                "description": r.get("description"),
+                "category": statement_parser.guess_category(r.get("description", "")),
+            } for r in raw_candidates if r.get("date") and r.get("amount")]
+            skipped = len(raw_candidates) - len(candidates)
+            source_type = "pdf"
+        else:
+            candidates, skipped = statement_parser.parse_csv(content)
+            source_type = "csv"
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=f"Failed to parse statement: {e}")
+
+    existing = db.query(models.Transaction).filter(models.Transaction.user_id == current_user.id).all()
+    _mark_duplicates(candidates, existing)
+
+    return schemas.ImportParseResponse(
+        filename=filename,
+        source_type=source_type,
+        candidates=candidates,
+        skipped_rows=skipped,
+    )
+
+
+@router.post("/import/commit", response_model=list[schemas.Transaction])
+def commit_import(
+    payload: schemas.ImportCommitRequest,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    created = []
+    for t in payload.transactions:
+        data = t.dict()
+        data["source"] = "imported"
+        db_transaction = models.Transaction(**data, user_id=current_user.id)
+        if not db_transaction.id:
+            db_transaction.id = str(uuid.uuid4())
+        db.add(db_transaction)
+        created.append(db_transaction)
+
+    db.commit()
+    for t in created:
+        db.refresh(t)
+    return created

--- a/backend/routers/import_router.py
+++ b/backend/routers/import_router.py
@@ -48,7 +48,15 @@ async def parse_statement(
             text = statement_parser.extract_pdf_text(content)
             if not text.strip():
                 raise HTTPException(status_code=400, detail="Couldn't extract any text from this PDF - it may be a scanned image rather than a text-based statement")
-            raw_candidates = await ai_service.parse_statement_text(text)
+            try:
+                raw_candidates = await ai_service.parse_statement_text(text)
+            except HTTPException:
+                raise
+            except Exception as e:
+                # Distinct from a malformed file (400/422) - this is "no AI backend is
+                # currently usable" (bad/missing Gemini key, Ollama down), a service-side
+                # config problem the user needs to fix, not a bad upload.
+                raise HTTPException(status_code=503, detail=str(e))
             candidates = [{
                 "date": r.get("date"),
                 "amount": abs(float(r.get("amount", 0))),
@@ -62,6 +70,8 @@ async def parse_statement(
         else:
             candidates, skipped = statement_parser.parse_csv(content)
             source_type = "csv"
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -56,6 +56,7 @@ class TransactionBase(BaseModel):
     date: str
     remarks: Optional[str] = None
     linked_debt_id: Optional[str] = None
+    source: str = 'manual'
 
 class TransactionCreate(TransactionBase):
     id: Optional[str] = None
@@ -63,6 +64,26 @@ class TransactionCreate(TransactionBase):
 class Transaction(TransactionBase):
     id: str
     model_config = ConfigDict(from_attributes=True)
+
+# --- Statement Import Schemas ---
+class ImportCandidate(BaseModel):
+    date: str
+    amount: float
+    type: str  # 'income' | 'expense'
+    merchant: Optional[str] = None
+    description: Optional[str] = None
+    category: str = 'Uncategorized'
+    is_duplicate: bool = False
+    duplicate_reason: Optional[str] = None
+
+class ImportParseResponse(BaseModel):
+    filename: str
+    source_type: str  # 'csv' | 'pdf'
+    candidates: List[ImportCandidate]
+    skipped_rows: int = 0
+
+class ImportCommitRequest(BaseModel):
+    transactions: List[TransactionCreate]
 
 class RecurringPlanBase(BaseModel):
     name: str

--- a/backend/statement_parser.py
+++ b/backend/statement_parser.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import re
-from datetime import datetime, date
+from datetime import datetime
 
 # Common bank-statement column name variants, lowercased. CSV parsing is fully
 # deterministic (no AI call) - it's fast, free, and bank CSV exports follow a small
@@ -26,11 +26,84 @@ CATEGORY_KEYWORDS = {
     "Rent": ["rent"],
     "Health": ["pharmacy", "hospital", "clinic", "apollo", "medplus"],
     "Salary": ["salary", "payroll"],
+    "Services": ["laundry", "dry clean", "tumbledry", "salon", "spa", "tailor"],
 }
 
 DATE_FORMATS = [
     "%Y-%m-%d", "%d-%m-%Y", "%d/%m/%Y", "%m/%d/%Y", "%d %b %Y", "%d %B %Y", "%b %d, %Y",
 ]
+
+# --- PII redaction -----------------------------------------------------------------
+# Indian bank/card statements routinely print account numbers, customer/CIF IDs, card
+# numbers, PAN, and registered phone numbers in headers, footers, and narration lines.
+# This runs on the FULL extracted text before any of it reaches an AI model (local or
+# cloud) - defense in depth, since Gemini is a third-party service and even the local
+# Ollama call shouldn't need to see this to extract transaction rows.
+_PAN_RE = re.compile(r"\b[A-Z]{5}[0-9]{4}[A-Z]\b")
+_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b")
+_PHONE_RE = re.compile(r"(?<!\d)(?:\+?91[-\s]?)?[6-9]\d{9}(?!\d)")
+# Any standalone run of 9+ digits (account/card/customer-ID numbers). Bank transaction
+# reference numbers embedded in UPI narration (e.g. "P2M/609427137208/SWIGGY") also
+# match this and get masked too - harmless, since clean_merchant_name() below extracts
+# the merchant name from narration structurally, not from the digits.
+_LONG_DIGITS_RE = re.compile(r"(?<!\d)\d{9,18}(?!\d)")
+
+
+def _mask_keep_last4(match: re.Match) -> str:
+    digits = match.group(0)
+    return "X" * (len(digits) - 4) + digits[-4:]
+
+
+def redact_pii(text: str) -> str:
+    """Best-effort PII scrub of statement text before it reaches any AI model."""
+    if not text:
+        return text
+    text = _PAN_RE.sub("[REDACTED-PAN]", text)
+    text = _EMAIL_RE.sub("[REDACTED-EMAIL]", text)
+    text = _PHONE_RE.sub("[REDACTED-PHONE]", text)
+    text = _LONG_DIGITS_RE.sub(_mask_keep_last4, text)
+    return text
+
+
+# --- Merchant name cleanup ----------------------------------------------------------
+# Indian UPI/NEFT/IMPS narration is highly structured but not merchant-friendly, e.g.
+# "UPI/P2M/609427137208/SWIGGY" or "/UPI/ICICI Bank /UPI/P2M/646142018709/SWIGGY". This
+# is deterministic and far more reliable than asking an LLM to guess a clean name from
+# raw narration - regex extraction of the trailing name segment, applied to every row
+# from both the CSV and AI-parsed PDF paths, so bulk imports don't leave the user with
+# hundreds of rows to hand-edit.
+# Transaction-ID segment is optional (some narration omits it, e.g. "UPI/P2M/TUMBLEDRY")
+# and may already be redact_pii()-masked to XXXXXXXX1234 by the time this runs, since
+# redaction happens on the full text before any per-row parsing - match digits or X's.
+_UPI_RE = re.compile(r"UPI/(P2[AM])/(?:[\dX]+/)?([A-Za-z0-9 .&'_-]+)", re.IGNORECASE)
+_NEFT_IMPS_RE = re.compile(r"(?:NEFT|IMPS|RTGS)[-/][\w]*[-/]([A-Za-z][A-Za-z0-9 .&'_-]{2,})", re.IGNORECASE)
+
+# UPI "P2A" (person-to-account) is a peer transfer, not a merchant purchase - route
+# these to Transfers instead of leaving them Uncategorized, which is what a bulk
+# statement import would otherwise dump most peer payments into.
+_PEER_TRANSFER_MARKERS = ("p2a",)
+
+
+def clean_merchant_name(raw: str) -> tuple:
+    """Returns (clean_name, is_peer_transfer). Falls back to a trimmed/title-cased
+    version of the original text when no known narration pattern matches."""
+    raw = (raw or "").strip()
+    if not raw:
+        return "", False
+
+    m = _UPI_RE.search(raw)
+    if m:
+        kind, name = m.group(1).lower(), m.group(2).strip(" /.-")
+        return (name.title() if name else raw.strip()), (kind in _PEER_TRANSFER_MARKERS)
+
+    m = _NEFT_IMPS_RE.search(raw)
+    if m:
+        return m.group(1).strip(" /.-").title(), False
+
+    # Generic cleanup: collapse repeated slashes/spaces from bank-formatted narration.
+    cleaned = re.sub(r"[/\\]+", " ", raw)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned[:60], False
 
 
 def _normalize_header(h: str) -> str:
@@ -66,7 +139,9 @@ def _parse_amount(raw: str):
         return None
 
 
-def guess_category(description: str) -> str:
+def guess_category(description: str, is_peer_transfer: bool = False) -> str:
+    if is_peer_transfer:
+        return "Transfers"
     text = (description or "").lower()
     for category, keywords in CATEGORY_KEYWORDS.items():
         if any(kw in text for kw in keywords):
@@ -77,7 +152,7 @@ def guess_category(description: str) -> str:
 def parse_csv(content: bytes):
     """Returns (candidates: list[dict], skipped_rows: int). Each candidate matches
     schemas.ImportCandidate's shape (as a plain dict, caller wraps it in the schema)."""
-    text = content.decode("utf-8-sig", errors="replace")
+    text = redact_pii(content.decode("utf-8-sig", errors="replace"))
     reader = csv.DictReader(io.StringIO(text))
     headers = reader.fieldnames or []
 
@@ -98,7 +173,7 @@ def parse_csv(content: bytes):
 
     for row in reader:
         parsed_date = _parse_date(row.get(date_col, ""))
-        description = (row.get(desc_col, "") or "").strip() if desc_col else ""
+        raw_description = (row.get(desc_col, "") or "").strip() if desc_col else ""
 
         if amount_col:
             amount = _parse_amount(row.get(amount_col))
@@ -122,13 +197,14 @@ def parse_csv(content: bytes):
             skipped += 1
             continue
 
+        merchant, is_peer_transfer = clean_merchant_name(raw_description)
         candidates.append({
             "date": parsed_date,
             "amount": amount,
             "type": txn_type,
-            "merchant": description[:60] if description else None,
-            "description": description or None,
-            "category": guess_category(description),
+            "merchant": merchant or None,
+            "description": raw_description or None,
+            "category": guess_category(merchant, is_peer_transfer),
         })
 
     return candidates, skipped
@@ -138,3 +214,22 @@ def extract_pdf_text(content: bytes) -> str:
     from pypdf import PdfReader
     reader = PdfReader(io.BytesIO(content))
     return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+
+def chunk_text_by_lines(text: str, max_chars: int) -> list:
+    """Splits text into line-respecting chunks, each under max_chars - used so a
+    multi-page statement gets sent across several AI calls instead of being silently
+    truncated to whatever fit in one prompt."""
+    lines = text.split("\n")
+    chunks = []
+    current, current_len = [], 0
+    for line in lines:
+        line_len = len(line) + 1
+        if current and current_len + line_len > max_chars:
+            chunks.append("\n".join(current))
+            current, current_len = [], 0
+        current.append(line)
+        current_len += line_len
+    if current:
+        chunks.append("\n".join(current))
+    return chunks

--- a/backend/statement_parser.py
+++ b/backend/statement_parser.py
@@ -1,0 +1,140 @@
+import csv
+import io
+import re
+from datetime import datetime, date
+
+# Common bank-statement column name variants, lowercased. CSV parsing is fully
+# deterministic (no AI call) - it's fast, free, and bank CSV exports follow a small
+# number of well-known column conventions, so heuristic mapping covers the common case.
+DATE_COLUMNS = {"date", "transaction date", "txn date", "value date", "posting date"}
+DESCRIPTION_COLUMNS = {"description", "narration", "details", "particulars", "remarks", "transaction details"}
+AMOUNT_COLUMNS = {"amount", "transaction amount"}
+DEBIT_COLUMNS = {"debit", "withdrawal", "withdrawal amount", "debit amount"}
+CREDIT_COLUMNS = {"credit", "deposit", "deposit amount", "credit amount"}
+
+# Tiny merchant-keyword -> category map for a reasonable first-pass guess. Deliberately
+# not AI-driven per row - the user has already flagged AI Quick Add as "very slow", and
+# calling a model per CSV row would compound that. The Review screen lets the user fix
+# any row's category before committing, so a rough heuristic here is enough.
+CATEGORY_KEYWORDS = {
+    "Food": ["swiggy", "zomato", "restaurant", "cafe", "food", "eatery", "dining"],
+    "Groceries": ["grocery", "supermarket", "bigbasket", "blinkit", "zepto", "dmart"],
+    "Transport": ["uber", "ola", "metro", "fuel", "petrol", "diesel", "irctc", "flight"],
+    "Shopping": ["amazon", "flipkart", "myntra", "ajio", "mall"],
+    "Bills": ["electricity", "water bill", "broadband", "recharge", "dth", "gas bill"],
+    "Entertainment": ["netflix", "spotify", "prime video", "hotstar", "movie", "bookmyshow"],
+    "Rent": ["rent"],
+    "Health": ["pharmacy", "hospital", "clinic", "apollo", "medplus"],
+    "Salary": ["salary", "payroll"],
+}
+
+DATE_FORMATS = [
+    "%Y-%m-%d", "%d-%m-%Y", "%d/%m/%Y", "%m/%d/%Y", "%d %b %Y", "%d %B %Y", "%b %d, %Y",
+]
+
+
+def _normalize_header(h: str) -> str:
+    return re.sub(r"\s+", " ", (h or "").strip().lower())
+
+
+def _find_column(headers: list, candidates: set):
+    for h in headers:
+        if _normalize_header(h) in candidates:
+            return h
+    return None
+
+
+def _parse_date(raw: str):
+    raw = (raw or "").strip()
+    for fmt in DATE_FORMATS:
+        try:
+            return datetime.strptime(raw, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return None
+
+
+def _parse_amount(raw: str):
+    if raw is None:
+        return None
+    cleaned = re.sub(r"[^\d.\-]", "", str(raw).strip())
+    if not cleaned or cleaned in ("-", "."):
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def guess_category(description: str) -> str:
+    text = (description or "").lower()
+    for category, keywords in CATEGORY_KEYWORDS.items():
+        if any(kw in text for kw in keywords):
+            return category
+    return "Uncategorized"
+
+
+def parse_csv(content: bytes):
+    """Returns (candidates: list[dict], skipped_rows: int). Each candidate matches
+    schemas.ImportCandidate's shape (as a plain dict, caller wraps it in the schema)."""
+    text = content.decode("utf-8-sig", errors="replace")
+    reader = csv.DictReader(io.StringIO(text))
+    headers = reader.fieldnames or []
+
+    date_col = _find_column(headers, DATE_COLUMNS)
+    desc_col = _find_column(headers, DESCRIPTION_COLUMNS)
+    amount_col = _find_column(headers, AMOUNT_COLUMNS)
+    debit_col = _find_column(headers, DEBIT_COLUMNS)
+    credit_col = _find_column(headers, CREDIT_COLUMNS)
+
+    if not date_col or (not amount_col and not (debit_col or credit_col)):
+        raise ValueError(
+            "Couldn't find recognizable Date/Amount (or Debit/Credit) columns in this CSV. "
+            f"Found columns: {', '.join(headers) if headers else 'none'}"
+        )
+
+    candidates = []
+    skipped = 0
+
+    for row in reader:
+        parsed_date = _parse_date(row.get(date_col, ""))
+        description = (row.get(desc_col, "") or "").strip() if desc_col else ""
+
+        if amount_col:
+            amount = _parse_amount(row.get(amount_col))
+            if amount is None:
+                skipped += 1
+                continue
+            txn_type = "income" if amount >= 0 else "expense"
+            amount = abs(amount)
+        else:
+            debit = _parse_amount(row.get(debit_col)) if debit_col else None
+            credit = _parse_amount(row.get(credit_col)) if credit_col else None
+            if credit:
+                amount, txn_type = credit, "income"
+            elif debit:
+                amount, txn_type = debit, "expense"
+            else:
+                skipped += 1
+                continue
+
+        if not parsed_date or not amount:
+            skipped += 1
+            continue
+
+        candidates.append({
+            "date": parsed_date,
+            "amount": amount,
+            "type": txn_type,
+            "merchant": description[:60] if description else None,
+            "description": description or None,
+            "category": guess_category(description),
+        })
+
+    return candidates, skipped
+
+
+def extract_pdf_text(content: bytes) -> str:
+    from pypdf import PdfReader
+    reader = PdfReader(io.BytesIO(content))
+    return "\n".join(page.extract_text() or "" for page in reader.pages)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bufin",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ImportReviewModal.jsx
+++ b/src/components/ImportReviewModal.jsx
@@ -108,9 +108,12 @@ const ImportReviewModal = ({ isOpen, onClose }) => {
             )}
 
             {stage === 'parsing' && (
-                <div className="flex flex-col items-center justify-center gap-3 py-12">
+                <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
                     <Loader2 className="h-6 w-6 animate-spin text-primary" />
                     <p className="text-sm text-muted-foreground">Reading your statement...</p>
+                    <p className="text-xs text-muted-foreground max-w-xs">
+                        A multi-page PDF can take a couple of minutes - each page is read and verified individually so nothing gets silently dropped.
+                    </p>
                 </div>
             )}
 

--- a/src/components/ImportReviewModal.jsx
+++ b/src/components/ImportReviewModal.jsx
@@ -1,0 +1,209 @@
+import React, { useRef, useState } from 'react';
+import Dialog from './ui/dialog';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+import PendingActionCard from './PendingActionCard';
+import EmptyState from './EmptyState';
+import { Upload, FileText, Loader2, AlertTriangle } from 'lucide-react';
+import { getCategoryMeta } from '../lib/categoryMeta';
+import { formatMoney } from '../lib/money';
+import { useFinancial } from '../context/FinancialContext';
+import { useToast } from '../context/ToastContext';
+import { api } from '../lib/api';
+
+// Statement upload -> parse -> review -> merge into the ledger. First real consumer of
+// PendingActionCard (spec'd in Phase 5, built here in Phase 6) - each parsed row is a
+// pending action the user confirms, edits, or skips before anything is written.
+const ImportReviewModal = ({ isOpen, onClose }) => {
+    const { importTransactions, categories } = useFinancial();
+    const { toast } = useToast();
+    const fileInputRef = useRef(null);
+
+    const [stage, setStage] = useState('upload'); // upload | parsing | review | committing
+    const [parseResult, setParseResult] = useState(null);
+    const [rows, setRows] = useState([]); // [{ ...candidate, selected, editing }]
+    const [error, setError] = useState('');
+
+    const reset = () => {
+        setStage('upload');
+        setParseResult(null);
+        setRows([]);
+        setError('');
+    };
+
+    const handleClose = () => {
+        reset();
+        onClose();
+    };
+
+    const handleFileSelect = async (e) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        setError('');
+        setStage('parsing');
+        try {
+            const result = await api.parseStatement(file);
+            setParseResult(result);
+            setRows(result.candidates.map((c) => ({ ...c, selected: !c.is_duplicate, editing: false })));
+            setStage('review');
+        } catch (err) {
+            setError(err.message || 'Failed to parse statement');
+            setStage('upload');
+        } finally {
+            if (fileInputRef.current) fileInputRef.current.value = '';
+        }
+    };
+
+    const updateRow = (idx, patch) => {
+        setRows((prev) => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+    };
+
+    const selectedCount = rows.filter((r) => r.selected).length;
+
+    const handleCommit = async () => {
+        const toImport = rows.filter((r) => r.selected);
+        if (toImport.length === 0) return;
+        setStage('committing');
+        try {
+            await importTransactions(toImport);
+            toast({ title: 'Import complete', description: `${toImport.length} transaction${toImport.length === 1 ? '' : 's'} added to your ledger.` });
+            handleClose();
+        } catch (err) {
+            setError(err.message || 'Failed to import transactions');
+            setStage('review');
+        }
+    };
+
+    return (
+        <Dialog isOpen={isOpen} onClose={handleClose} title="Import Statement">
+            {stage === 'upload' && (
+                <div className="space-y-4">
+                    <p className="text-sm text-muted-foreground">
+                        Upload a CSV or PDF bank/card statement. You'll review every transaction before anything is added to your ledger.
+                    </p>
+                    {error && (
+                        <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md flex items-center gap-2">
+                            <AlertTriangle className="h-4 w-4 shrink-0" />
+                            {error}
+                        </div>
+                    )}
+                    <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="w-full flex flex-col items-center justify-center gap-2 p-8 rounded-xl border-2 border-dashed border-border hover:border-primary/50 hover:bg-secondary/30 transition-colors duration-fast"
+                    >
+                        <Upload className="h-8 w-8 text-muted-foreground" />
+                        <span className="text-sm font-medium text-foreground">Click to choose a file</span>
+                        <span className="text-xs text-muted-foreground">CSV or PDF, up to 5MB</span>
+                    </button>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept=".csv,.pdf,application/pdf,text/csv"
+                        className="hidden"
+                        onChange={handleFileSelect}
+                    />
+                </div>
+            )}
+
+            {stage === 'parsing' && (
+                <div className="flex flex-col items-center justify-center gap-3 py-12">
+                    <Loader2 className="h-6 w-6 animate-spin text-primary" />
+                    <p className="text-sm text-muted-foreground">Reading your statement...</p>
+                </div>
+            )}
+
+            {stage === 'review' && parseResult && (
+                <div className="space-y-4">
+                    <div className="flex items-center justify-between text-sm">
+                        <span className="flex items-center gap-2 text-foreground font-medium">
+                            <FileText className="h-4 w-4 text-primary" /> {parseResult.filename}
+                        </span>
+                        <span className="text-muted-foreground">{selectedCount} of {rows.length} selected</span>
+                    </div>
+
+                    {parseResult.skipped_rows > 0 && (
+                        <p className="text-xs text-muted-foreground">{parseResult.skipped_rows} row(s) couldn't be parsed and were skipped.</p>
+                    )}
+
+                    {error && (
+                        <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md flex items-center gap-2">
+                            <AlertTriangle className="h-4 w-4 shrink-0" />
+                            {error}
+                        </div>
+                    )}
+
+                    {rows.length === 0 ? (
+                        <EmptyState title="No transactions found" description="This file didn't contain any recognizable transactions." icon={FileText} />
+                    ) : (
+                        <div className="space-y-2 max-h-96 overflow-y-auto pr-1">
+                            {rows.map((row, idx) => {
+                                const meta = getCategoryMeta(row.category);
+                                return (
+                                    <PendingActionCard
+                                        key={idx}
+                                        icon={meta.icon}
+                                        title={row.merchant || row.description || 'Unknown'}
+                                        detail={`${row.date} · ${row.type === 'income' ? '+' : '-'}${formatMoney(row.amount)} · ${row.category}${row.is_duplicate ? ' · Possible duplicate' : ''}`}
+                                        source={row.is_duplicate ? 'Duplicate' : undefined}
+                                        selected={row.selected}
+                                        onConfirm={() => updateRow(idx, { selected: true })}
+                                        onCancel={() => updateRow(idx, { selected: false })}
+                                        onEdit={() => updateRow(idx, { editing: !row.editing })}
+                                    >
+                                        {row.editing && (
+                                            <div className="flex flex-wrap gap-2 p-3 pt-0">
+                                                <Input
+                                                    type="number"
+                                                    value={row.amount}
+                                                    onChange={(e) => updateRow(idx, { amount: e.target.value })}
+                                                    className="h-8 w-28 text-sm"
+                                                />
+                                                <Select value={row.category} onValueChange={(v) => updateRow(idx, { category: v })} className="h-8 w-40">
+                                                    <SelectTrigger>
+                                                        <SelectValue />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {categories.map((c) => (
+                                                            <SelectItem key={c} value={c}>{c}</SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                                <Select value={row.type} onValueChange={(v) => updateRow(idx, { type: v })} className="h-8 w-32">
+                                                    <SelectTrigger>
+                                                        <SelectValue />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        <SelectItem value="expense">Expense</SelectItem>
+                                                        <SelectItem value="income">Income</SelectItem>
+                                                    </SelectContent>
+                                                </Select>
+                                            </div>
+                                        )}
+                                    </PendingActionCard>
+                                );
+                            })}
+                        </div>
+                    )}
+
+                    <div className="flex justify-end gap-2 pt-2 border-t border-border">
+                        <Button variant="outline" onClick={handleClose}>Cancel</Button>
+                        <Button onClick={handleCommit} disabled={selectedCount === 0}>
+                            Import {selectedCount} transaction{selectedCount === 1 ? '' : 's'}
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            {stage === 'committing' && (
+                <div className="flex flex-col items-center justify-center gap-3 py-12">
+                    <Loader2 className="h-6 w-6 animate-spin text-primary" />
+                    <p className="text-sm text-muted-foreground">Adding to your ledger...</p>
+                </div>
+            )}
+        </Dialog>
+    );
+};
+
+export default ImportReviewModal;

--- a/src/components/PendingActionCard.jsx
+++ b/src/components/PendingActionCard.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Button } from './ui/button';
+import { Check, X, Pencil } from 'lucide-react';
+import { cn } from '../lib/utils';
+
+// Shared row for any "AI proposed this, confirm/edit/skip it" flow - statement import
+// review is the first consumer; agentic coach actions and receipt parsing (later phases)
+// reuse this same shape instead of each building their own review UI.
+const PendingActionCard = ({ icon: Icon, title, detail, source, selected = true, onConfirm, onEdit, onCancel, children }) => {
+    return (
+        <div className={cn(
+            "rounded-lg border transition-colors duration-fast",
+            selected ? "border-primary/30 bg-primary/5" : "border-border bg-secondary/20 opacity-60"
+        )}>
+            <div className="flex items-center gap-3 p-3">
+                {Icon && (
+                    <div className="h-9 w-9 rounded-full bg-secondary flex items-center justify-center shrink-0">
+                        <Icon className="h-4 w-4 text-muted-foreground" />
+                    </div>
+                )}
+                <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-foreground truncate">{title}</p>
+                    <p className="text-xs text-muted-foreground truncate">{detail}</p>
+                </div>
+                {source && (
+                    <span className="hidden sm:inline-block text-[10px] uppercase tracking-wide text-muted-foreground bg-secondary px-1.5 py-0.5 rounded-full shrink-0">
+                        {source}
+                    </span>
+                )}
+                <div className="flex items-center gap-1 shrink-0">
+                    {onEdit && (
+                        <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-primary" onClick={onEdit} title="Edit">
+                            <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                    )}
+                    {selected ? (
+                        <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive" onClick={onCancel} title="Skip this one">
+                            <X className="h-4 w-4" />
+                        </Button>
+                    ) : (
+                        <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-success" onClick={onConfirm} title="Include this one">
+                            <Check className="h-4 w-4" />
+                        </Button>
+                    )}
+                </div>
+            </div>
+            {children}
+        </div>
+    );
+};
+
+export default PendingActionCard;

--- a/src/components/TransactionTable.jsx
+++ b/src/components/TransactionTable.jsx
@@ -3,7 +3,7 @@ import { useFinancial } from '../context/FinancialContext';
 import { Card, CardContent, CardHeader } from './ui/card';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
-import { Trash2, Edit2, UserPlus, Search } from 'lucide-react';
+import { Trash2, Edit2, UserPlus, Search, Upload } from 'lucide-react';
 import Dialog from './ui/dialog';
 import AddTransactionForm from './AddTransactionForm';
 import { AddDebtForm } from './PlannerForms';
@@ -12,6 +12,7 @@ import { Skeleton } from './ui/skeleton';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { getCategoryMeta } from '../lib/categoryMeta';
 import { formatSignedMoney } from '../lib/money';
+import ImportReviewModal from './ImportReviewModal';
 
 const dayLabel = (dateStr) => {
     const d = new Date(dateStr);
@@ -31,6 +32,7 @@ const TransactionTable = () => {
     const [viewingTransaction, setViewingTransaction] = useState(null);
     const [filterType, setFilterType] = useState('all'); // all, income, expense, debt
     const [search, setSearch] = useState('');
+    const [isImportOpen, setIsImportOpen] = useState(false);
 
     const formatSigned = (amount, type) => (isPrivacyMode ? '••••••' : formatSignedMoney(amount, type));
 
@@ -90,17 +92,22 @@ const TransactionTable = () => {
                             className="pl-9"
                         />
                     </div>
-                    <Select value={filterType} onValueChange={setFilterType} className="sm:w-48">
-                        <SelectTrigger>
-                            <SelectValue placeholder="Filter" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            <SelectItem value="all">All Transactions</SelectItem>
-                            <SelectItem value="income">Income Only</SelectItem>
-                            <SelectItem value="expense">Expense Only</SelectItem>
-                            <SelectItem value="debt">Debts (Owed)</SelectItem>
-                        </SelectContent>
-                    </Select>
+                    <div className="flex gap-2">
+                        <Select value={filterType} onValueChange={setFilterType} className="sm:w-48">
+                            <SelectTrigger>
+                                <SelectValue placeholder="Filter" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="all">All Transactions</SelectItem>
+                                <SelectItem value="income">Income Only</SelectItem>
+                                <SelectItem value="expense">Expense Only</SelectItem>
+                                <SelectItem value="debt">Debts (Owed)</SelectItem>
+                            </SelectContent>
+                        </Select>
+                        <Button variant="outline" onClick={() => setIsImportOpen(true)} className="gap-2 shrink-0">
+                            <Upload className="h-4 w-4" /> Import
+                        </Button>
+                    </div>
                 </CardHeader>
                 <CardContent className="divide-y divide-border">
                     {isDataLoading ? (
@@ -141,8 +148,13 @@ const TransactionTable = () => {
                                                     <meta.icon className="h-4 w-4" />
                                                 </div>
                                                 <div className="flex-1 min-w-0">
-                                                    <p className="text-sm font-medium text-foreground truncate">
+                                                    <p className="text-sm font-medium text-foreground truncate flex items-center gap-1.5">
                                                         {t.merchant || t.personName || t.description || t.category}
+                                                        {t.source === 'imported' && (
+                                                            <span className="shrink-0 text-[9px] uppercase tracking-wide font-semibold text-primary bg-primary/10 px-1.5 py-0.5 rounded-full">
+                                                                Imported
+                                                            </span>
+                                                        )}
                                                     </p>
                                                     <p className="text-xs text-muted-foreground truncate">
                                                         {t.category}{t.description ? ` • ${t.description}` : ''}
@@ -234,6 +246,10 @@ const TransactionTable = () => {
                                 <span className="text-muted-foreground block">Necessity</span>
                                 <span className="capitalize">{viewingTransaction.necessity || '-'}</span>
                             </div>
+                            <div>
+                                <span className="text-muted-foreground block">Source</span>
+                                <span className="capitalize">{viewingTransaction.source === 'imported' ? 'Imported from statement' : 'Manual entry'}</span>
+                            </div>
                         </div>
 
                         <div className="bg-muted/30 p-3 rounded-md">
@@ -278,6 +294,8 @@ const TransactionTable = () => {
                     />
                 )}
             </Dialog>
+
+            <ImportReviewModal isOpen={isImportOpen} onClose={() => setIsImportOpen(false)} />
         </>
     );
 };

--- a/src/context/FinancialContext.jsx
+++ b/src/context/FinancialContext.jsx
@@ -123,6 +123,24 @@ export const FinancialProvider = ({ children }) => {
     }
   };
 
+  // Bulk-commits reviewed statement-import candidates in one request, then prepends
+  // them all to local state at once (rather than one addTransaction() call per row,
+  // which would be N round-trips for a large statement).
+  const importTransactions = async (candidateTransactions) => {
+    const created = await api.commitImport(candidateTransactions.map(c => ({
+      amount: parseFloat(c.amount),
+      category: c.category,
+      description: c.description || c.merchant || 'Imported transaction',
+      merchant: c.merchant || null,
+      type: c.type,
+      necessity: 'variable',
+      date: c.date,
+      remarks: null,
+    })));
+    setTransactions(prev => [...created, ...prev]);
+    return created;
+  };
+
   const deleteTransaction = async (id) => {
     try {
       // If this transaction was auto-created by repaying a debt, revert the debt
@@ -458,6 +476,7 @@ export const FinancialProvider = ({ children }) => {
       isDataLoading,
       transactions,
       addTransaction,
+      importTransactions,
       updateTransaction,
       deleteTransaction,
       recurringPlans,

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -116,6 +116,36 @@ export const api = {
         if (!response.ok) throw new Error('Failed to delete transaction');
         return response.json();
     },
+    parseStatement: async (file) => {
+        const token = localStorage.getItem('token');
+        const headers = token ? { 'Authorization': `Bearer ${token}` } : {};
+        const formData = new FormData();
+        formData.append('file', file);
+        const response = await fetch(`${API_URL}/import/parse`, {
+            method: 'POST',
+            headers,
+            body: formData,
+        });
+        if (!response.ok) {
+            const err = await response.json().catch(() => ({}));
+            throw new Error(err.detail || 'Failed to parse statement');
+        }
+        return response.json();
+    },
+    commitImport: async (transactions) => {
+        const token = localStorage.getItem('token');
+        const headers = {
+            'Content-Type': 'application/json',
+            ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+        };
+        const response = await fetch(`${API_URL}/import/commit`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ transactions }),
+        });
+        if (!response.ok) throw new Error('Failed to import transactions');
+        return response.json();
+    },
 
     // Recurring Plans
     getRecurringPlans: async () => {


### PR DESCRIPTION
## Summary
Phase 6 of the roadmap: statement upload → parse → review → merge into the ledger. Official bank-API/Account-Aggregator integrations remain out of scope (licensing/permissions) - this is file-based only (CSV/PDF), covering the practical "stop typing every transaction" need without needing bank partnerships. Full spec/rationale in the plan file, section 8.

### Design decisions
- **CSV parsing is fully deterministic, no AI call.** Bank CSV exports follow well-known column conventions (Date/Description/Amount, or Date/Description/Debit/Credit) - heuristic header matching handles the common case instantly and for free.
- **PDF parsing is one AI call per document, not per line.** Text is extracted via `pypdf`, then the whole statement goes through a single prompt returning all transactions as one JSON array, routed through the existing Ollama-first/Gemini-fallback pattern already used for `classify_transaction`.
- **Category guessing is a small keyword dictionary, not AI**, even for PDF rows - AI Quick Add has already been flagged as slow, and calling a model per parsed row (a statement can have 50+ rows) would compound that. The review screen lets the user fix any row before committing.
- **Dedupe is same-date + same-amount + same-type matching** against existing transactions. Matched rows default to unselected in review rather than being silently merged or blocked.
- **`PendingActionCard` built here as the first real consumer**, per its Phase 5 spec (`{icon, title, detail, source, onConfirm, onEdit, onCancel}`) - intentionally left unbuilt in Phase 5 since there was no consumer yet. Same component is spec'd for reuse in the agentic coach and receipt-parsing phases.
- **Source provenance**: new `transactions.source` column (`manual` | `imported`) drives an "Imported" badge on Ledger rows and a Source field in the transaction detail dialog.

### What's in this PR
**Backend**
- `source` column on `transactions` + Alembic migration
- `statement_parser.py`: deterministic CSV column-heuristic parser, PDF text extraction, keyword-based category guesser
- `ai_service.py`: `parse_statement_text()` for PDF line-item extraction
- `routers/import_router.py`: `POST /api/import/parse` (parses + dedupes, persists nothing) and `POST /api/import/commit` (bulk-creates confirmed rows)

**Frontend**
- `PendingActionCard.jsx`: shared review-row component
- `parseStatement()`/`commitImport()` API calls, `importTransactions()` bulk context action
- `ImportReviewModal.jsx`: upload → parse → review (each row a `PendingActionCard`, inline edit, duplicates pre-unselected) → commit
- Ledger: "Import" button, "Imported" badge on matching rows, Source field in the detail dialog

Version bumped to **2.1.0** (frontend + backend, in sync).

### Not in this PR
- Scanned/image-only PDFs (no OCR) - returns a clear error rather than silently producing nothing
- Multi-file batch upload (one statement per session)
- Bank-specific column presets beyond the generic heuristic - an unusual layout surfaces a clear error instead of silently misparsing

## Test plan
- [x] `npm run build` clean (only pre-existing duplicate-key warnings, confirmed unrelated via `git stash` diff)
- [x] Backend imports cleanly, migration applies via `alembic upgrade head`
- [x] `/api/import/parse` and `/api/import/commit` confirmed registered via live OpenAPI schema
- [x] CSV parser sanity-tested against a sample statement (mixed debit/credit columns, mixed date formats) - correct output
- [ ] Manual walkthrough requested: upload a real CSV, review the parsed rows, edit one, skip a duplicate, commit, confirm the transactions land in the Ledger with the "Imported" badge and correct Source field
