### PR TITLE
fix: remove duplicate deleteWishlistItem and deleteSavingsGoal keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bufin",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bufin",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@tailwindcss/vite": "^4.1.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bufin",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bufin",
-      "version": "2.0.0",
+      "version": "0.0.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@tailwindcss/vite": "^4.1.17",

--- a/src/context/FinancialContext.jsx
+++ b/src/context/FinancialContext.jsx
@@ -476,7 +476,6 @@ export const FinancialProvider = ({ children }) => {
       wishlist,
       addWishlistItem,
       deleteWishlistItem,
-      deleteWishlistItem,
       balance, // Total Net Worth
       safeBalance, // Spendable Cash (Net Worth - Jars)
       untouchedSavings, // Total in Jars
@@ -493,7 +492,6 @@ export const FinancialProvider = ({ children }) => {
       addSavingsGoal,
       updateSavingsGoal,
       editSavingsGoal,
-      deleteSavingsGoal,
       deleteSavingsGoal,
       ignoredMerchants,
       ignoreMerchant


### PR DESCRIPTION
Fixes #15

## fix: remove duplicate deleteWishlistItem and deleteSavingsGoal keys

### Problem
`src/context/FinancialContext.jsx`'s context-value object literal had two duplicate keys, causing esbuild warnings on every build:

    [plugin vite:esbuild] src/context/FinancialContext.jsx: Duplicate key "deleteWishlistItem" in object literal
    [plugin vite:esbuild] src/context/FinancialContext.jsx: Duplicate key "deleteSavingsGoal" in object literal

No functional bug (JS silently lets the later key win), just build noise.

### Fix
Confirmed both duplicate pairs referenced the same single function (only one `deleteWishlistItem` and one `deleteSavingsGoal` defined in the file), then removed the redundant line for each.

### Testing
`npm run build` — the two duplicate-key warnings are gone, build succeeds cleanly.

### Files changed
- `src/context/FinancialContext.jsx`