### PR TITLE
fix: preserve UTC timestamps for impulse cooldown

### DIFF
--- a/backend/routers/goals.py
+++ b/backend/routers/goals.py
@@ -6,7 +6,7 @@ from database import get_db
 import models
 from .auth import get_current_user
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 router = APIRouter()
 
@@ -110,7 +110,10 @@ def create_wishlist_item(item: WishlistItemCreate, db: Session = Depends(get_db)
         user_id=current_user.id,
         name=item.name,
         cost=item.cost,
-        addedAt=datetime.utcnow().isoformat()
+        # Include the UTC offset.  An offset-less ISO timestamp is interpreted as
+        # local time by browsers, which made the client-side 48-hour cooldown
+        # start several hours early for wishlist items created by this endpoint.
+        addedAt=datetime.now(timezone.utc).isoformat()
     )
     db.add(db_item)
     db.commit()

--- a/src/components/ImpulseControl.jsx
+++ b/src/components/ImpulseControl.jsx
@@ -8,6 +8,15 @@ import EmptyState from './EmptyState';
 
 const COOLDOWN_MS = 48 * 60 * 60 * 1000;
 
+const parseAddedAt = (addedAt) => {
+    // Older API records were generated with Python's utcnow().isoformat(), which
+    // has no timezone suffix. JavaScript treats those values as local time even
+    // though the server meant UTC. Keep existing countdowns accurate while new
+    // records use an explicit +00:00 offset.
+    const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/i.test(addedAt);
+    return new Date(hasTimezone ? addedAt : `${addedAt}Z`);
+};
+
 const ImpulseControl = () => {
     const { wishlist, addWishlistItem, deleteWishlistItem, addTransaction } = useFinancial();
     const [newItem, setNewItem] = useState('');
@@ -36,7 +45,7 @@ const ImpulseControl = () => {
     // Helper to calculate time remaining in HH:MM:SS format
     const getTimeRemaining = (addedAt) => {
         const now = new Date();
-        const added = new Date(addedAt);
+        const added = parseAddedAt(addedAt);
         const diff = COOLDOWN_MS - (now - added);
 
         if (diff <= 0) return null; // Cooldown over
@@ -50,8 +59,8 @@ const ImpulseControl = () => {
     // Real elapsed-cooldown percentage, replacing the old static "100% width" fake timer bar.
     const getElapsedPct = (addedAt) => {
         const now = new Date();
-        const added = new Date(addedAt);
-        return Math.min(100, ((now - added) / COOLDOWN_MS) * 100);
+        const added = parseAddedAt(addedAt);
+        return Math.max(0, Math.min(100, ((now - added) / COOLDOWN_MS) * 100));
     };
 
     // Force re-render every second to update timers


### PR DESCRIPTION
Fixes #11

  ## Summary

  The Impulse Control 48-hour cooldown could start several hours early because the backend generated UTC timestamps without a timezone offset. Browsers interpret
  offset-less ISO timestamps as local time.

  This change:

  - Serializes new wishlist timestamps with an explicit UTC offset.
  - Treats legacy offset-less timestamps as UTC in the frontend.
  - Clamps cooldown-progress values between 0% and 100%.

  ## Verification

  - `npm run build`
  - `python3 -m py_compile backend/routers/goals.py`

  ## Notes

  The build still reports the existing duplicate-key warnings tracked in #15; they are unrelated to this change.